### PR TITLE
Implementation of two types of pause on worker

### DIFF
--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -371,6 +371,9 @@ class PyNcclCommunicator:
     def group_end(self):
         self.nccl.ncclGroupEnd()
 
+    def nccl_abort_comm(self):
+        self.nccl.ncclCommAbort(self.comm)
+
     def register_comm_window(self, tensor: torch.Tensor):
         return self.nccl.ncclCommWindowRegister(
             self.comm,

--- a/vllm/distributed/device_communicators/pynccl_wrapper.py
+++ b/vllm/distributed/device_communicators/pynccl_wrapper.py
@@ -274,6 +274,8 @@ class NCCLLibrary:
         # it is better not to call it at all.
         # ncclResult_t  ncclCommDestroy(ncclComm_t comm);
         Function("ncclCommDestroy", ncclResult_t, [ncclComm_t]),
+        # ncclResult_t ncclCommAbort(ncclComm_t comm)
+        Function("ncclCommAbort", ncclResult_t, [ncclComm_t]),
         # ncclResult_t ncclGroupStart();
         Function("ncclGroupStart", ncclResult_t, []),
         # ncclResult_t ncclGroupEnd();
@@ -531,6 +533,9 @@ class NCCLLibrary:
 
     def ncclCommDestroy(self, comm: ncclComm_t) -> None:
         self.NCCL_CHECK(self._funcs["ncclCommDestroy"](comm))
+
+    def ncclCommAbort(self, comm: ncclComm_t) -> None:
+        self.NCCL_CHECK(self._funcs["ncclCommAbort"](comm))
 
     def ncclGroupStart(self) -> None:
         self.NCCL_CHECK(self._funcs["ncclGroupStart"]())

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1515,9 +1515,31 @@ def get_node_count() -> int:
 
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
-    initialized_group_list = get_all_model_groups()
-    for group in initialized_group_list:
-        group.destroy()
+    global _TP
+
+    if _TP:
+        _TP.destroy()
+    _TP = None
+
+    global _PP
+    if _PP:
+        _PP.destroy()
+    _PP = None
+
+    global _DCP
+    if _DCP:
+        _DCP.destroy()
+    _DCP = None
+
+    global _DP
+    if _DP:
+        _DP.destroy()
+    _DP = None
+
+    global _EP
+    if _EP:
+        _EP.destroy()
+    _EP = None
 
 
 def destroy_distributed_environment():

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1111,6 +1111,31 @@ def get_pipeline_model_parallel_group():
     return get_pp_group()
 
 
+def get_all_model_groups() -> list[GroupCoordinator]:
+    group_list = []
+    global _TP
+    if _TP:
+        group_list.append(_TP)
+
+    global _PP
+    if _PP:
+        group_list.append(_PP)
+
+    global _DCP
+    if _DCP:
+        group_list.append(_DCP)
+
+    global _DP
+    if _DP:
+        group_list.append(_DP)
+
+    global _EP
+    if _EP:
+        group_list.append(_EP)
+
+    return group_list
+
+
 @contextmanager
 def graph_capture(device: torch.device):
     """
@@ -1490,31 +1515,9 @@ def get_node_count() -> int:
 
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
-    global _TP
-
-    if _TP:
-        _TP.destroy()
-    _TP = None
-
-    global _PP
-    if _PP:
-        _PP.destroy()
-    _PP = None
-
-    global _DCP
-    if _DCP:
-        _DCP.destroy()
-    _DCP = None
-
-    global _DP
-    if _DP:
-        _DP.destroy()
-    _DP = None
-
-    global _EP
-    if _EP:
-        _EP.destroy()
-    _EP = None
+    initialized_group_list = get_all_model_groups()
+    for group in initialized_group_list:
+        group.destroy()
 
 
 def destroy_distributed_environment():

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -164,7 +164,9 @@ class EngineClient(ABC):
         """Perform a collective RPC call to the given path."""
         raise NotImplementedError
 
-    async def handle_fault(self, instruction: str, timeout: int = 300) -> bool:
+    async def handle_fault(
+        self, instruction: str, timeout: int = 300, **kwargs
+    ) -> bool:
         """send fault tolerance instruction to the engine"""
         raise NotImplementedError
 

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -69,10 +69,10 @@ async def send_fault_tolerance_instruction(request: Request) -> Response:
 
     fault_tolerance_instruction = request_dict.get("fault_tolerance_instruction")
     fault_tolerance_timeout = request_dict.get("fault_tolerance_timeout")
-
+    kwargs = request_dict.get("kwargs", {})
     assert engine is not None
     return await engine.handle_fault(
-        fault_tolerance_instruction, fault_tolerance_timeout
+        fault_tolerance_instruction, fault_tolerance_timeout, **kwargs
     )
 
 
@@ -81,7 +81,7 @@ async def get_fault_info() -> Response:
     """Health check."""
     assert engine is not None
     engine_exception_dict = await engine.exception_reporter()
-    return Response(engine_exception_dict, status_code=200)
+    return Response(json.dumps(engine_exception_dict), status_code=200)
 
 
 @with_cancellation

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1174,6 +1174,7 @@ async def send_fault_tolerance_instruction(raw_request: Request):
 
     fault_tolerance_instruction = body.get("fault_tolerance_instruction")
     fault_tolerance_timeout = body.get("fault_tolerance_timeout")
+    kwargs = body.get("kwargs", {})
 
     if fault_tolerance_instruction is None or fault_tolerance_timeout is None:
         raise HTTPException(
@@ -1199,7 +1200,7 @@ async def send_fault_tolerance_instruction(raw_request: Request):
         )
     try:
         execute_result = await client.handle_fault(
-            fault_tolerance_instruction, fault_tolerance_timeout
+            fault_tolerance_instruction, fault_tolerance_timeout, **kwargs
         )
         if execute_result:
             return JSONResponse(

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -789,9 +789,11 @@ class AsyncLLM(EngineClient):
                 custom_stat_loggers=None,
             )
 
-    async def handle_fault(self, instruction: str, timeout: int = 300) -> bool:
+    async def handle_fault(
+        self, instruction: str, timeout: int = 300, **kwargs
+    ) -> bool:
         """send fault tolerance instruction to the engine"""
-        return await self.engine_core.handle_fault(instruction, timeout)
+        return await self.engine_core.handle_fault(instruction, timeout, **kwargs)
 
     async def exception_reporter(self):
         """report exception in engine core"""

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -33,7 +33,7 @@ from vllm.utils.network_utils import (
     get_open_port,
     get_open_zmq_inproc_path,
     make_zmq_socket,
-    recv_msg,
+    recv_router_dealer_message,
 )
 from vllm.v1.engine import (
     EngineCoreOutputs,
@@ -417,7 +417,9 @@ class ClientGuard:
         error information from the engine core is missed.
         """
         while True:
-            sender_identity, message = recv_msg(self.fault_receiver_socket)
+            _, sender_identity, message = recv_router_dealer_message(
+                self.fault_receiver_socket
+            )
             if self.client_guard_dead:
                 logger.info("client guard dead, stop receiving fault")
                 break

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1237,7 +1237,7 @@ class FaultHandler:
         self.engine_exception_q_lock = engine_exception_q_lock
         self.engine_status_dict = engine_status_dict
 
-    async def handle_fault(self, instruction: str, timeout) -> bool:
+    async def handle_fault(self, instruction: str, timeout, **kwargs) -> bool:
         # TODO: Implement a thread-safe dictionary to mark statuses
         unhealthy_engine_list = await get_queue_snapshot(
             self.engine_exception_q, self.engine_exception_q_lock
@@ -1261,7 +1261,7 @@ class FaultHandler:
             ]
 
         await self.send_fault_tolerance_instruction(
-            client_cmd_registry_copy, instruction, timeout
+            client_cmd_registry_copy, instruction, timeout, **kwargs
         )
 
         execute_result = await self.process_instruction_result(
@@ -1274,9 +1274,9 @@ class FaultHandler:
         return execute_result
 
     async def send_fault_tolerance_instruction(
-        self, client_cmd_registry_copy, instruction, timeout
+        self, client_cmd_registry_copy, instruction, timeout, **kwargs
     ):
-        kwargs = {"timeout": timeout}
+        kwargs["timeout"] = timeout
         for identity in client_cmd_registry_copy:
             serialized_instruction = serialize_method_call(instruction, **kwargs)
             self.cmd_socket.send_multipart(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3,6 +3,7 @@
 
 import gc
 import itertools
+import threading
 import time
 from collections import defaultdict
 from collections.abc import Iterator
@@ -91,6 +92,7 @@ from vllm.v1.attention.backends.utils import (
     split_attn_metadata,
 )
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
+from vllm.v1.engine.exceptions import EngineLoopPausedError
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     ChunkedLocalAttentionSpec,
@@ -507,6 +509,12 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             device="cpu",
             pin_memory=self.pin_memory,
         )
+
+        self.pause_event = threading.Event()
+
+    def _check_pause_event(self):
+        if self.pause_event.is_set():
+            raise EngineLoopPausedError("Worker is paused.")
 
     def reset_mm_cache(self) -> None:
         if self.mm_budget:
@@ -2407,6 +2415,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         Returns:
             Model output tensor
         """
+        self._check_pause_event()
         return self.model(
             input_ids=input_ids,
             positions=positions,
@@ -3472,6 +3481,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     ubatch_slices=ubatch_slices,
                 ),
             ):
+                self._check_pause_event()
                 outputs = self.model(
                     input_ids=input_ids,
                     positions=positions,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -148,8 +148,7 @@ class WorkerGuard:
                 method, method_params = deserialize_method_call(cmd_str)
                 self.logger("Executing command: %s", method)
                 try:
-                    success = run_method(self, method, args=(), kwargs=method_params)
-                    self.logger(" Command (%s) succeeded: %s", method, success)
+                    run_method(self, method, args=(), kwargs=method_params)
 
                     # todo: need to send results back to engine core guard.
 
@@ -163,6 +162,7 @@ class WorkerGuard:
 
     def pause_by_signal(self):
         self.pause_event.set()
+        self.logger("Pause signal sent.")
         return True
 
     def pause_by_abort_communicators(self, timeout=5):
@@ -224,7 +224,11 @@ class WorkerGuard:
                 )
 
         self.communicator_aborted = True
-        return len(not_done) == 0
+        success = len(not_done) == 0
+        if success:
+            self.logger("Communicators are aborted.")
+        else:
+            self.logger("Communicators did not abort in time.", level="warning")
 
     def restart_worker(self):
         if self.communicator_aborted:


### PR DESCRIPTION
Implementation of two types of pause: a soft one by using flag signals and a hard one by aborting nccl communicators.

<!-- markdownlint-disable -->

## Purpose
To properly stop the execution of worker when pause command is sent.
## Test Plan
The scenario where a pause command is manually issued without any fault occurring (including both cases: when requests are being sent and when no requests are being sent) has been tested and verified to work correctly.
## Test Result
Passed.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

