### PR TITLE
[Distributed] Replace torch.distributed.new_group with stateless process groups

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -299,6 +299,33 @@ class ParallelConfig:
         should only be set by API server scale-out.
     """
 
+    enable_stateless_pg: bool = False
+    """
+    Whether to use stateless process group creation instead of
+    torch.distributed.new_group.
+
+    When set to True, enables stateless process group creation for distributed
+    communication, which provides better resource management and cleanup compared to
+    the standard torch.distributed.new_group approach. This is particularly useful
+    for scenarios requiring dynamic process group creation, improved isolation, and
+    deterministic resource release.
+
+    When set to False (default), uses torch.distributed.new_group for process group
+    creation, which is the standard PyTorch approach.
+
+    Key benefits of stateless process groups:
+    - Better resource cleanup and memory management
+    - Improved isolation between different process groups
+    - More deterministic initialization and destruction
+    - Enhanced debugging capabilities
+
+    Note:
+        This option requires proper initialization and cleanup of process group
+        resources. Ensure your distributed setup supports the chosen backend.
+        Stateless process groups may have different performance characteristics
+        compared to standard process groups.
+    """
+
     @field_validator("disable_nccl_for_dp_synchronization", mode="wrap")
     @classmethod
     def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:
@@ -530,6 +557,7 @@ class ParallelConfig:
             "worker_extension_cls",
             "_api_process_count",
             "_api_process_rank",
+            "enable_stateless_pg",
         }
 
         from vllm.config.utils import get_hash_factors, hash_factors

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -557,7 +557,6 @@ class ParallelConfig:
             "worker_extension_cls",
             "_api_process_count",
             "_api_process_rank",
-            "enable_stateless_pg",
         }
 
         from vllm.config.utils import get_hash_factors, hash_factors

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -321,10 +321,28 @@ class GroupCoordinator:
         self_device_group = None
         self_cpu_group = None
 
+        from vllm.config import get_current_vllm_config
+
+        config = get_current_vllm_config()
+
         for ranks in group_ranks:
-            device_group = torch.distributed.new_group(
-                ranks, backend=torch_distributed_backend
-            )
+            if config.parallel_config.enable_stateless_pg and len(ranks) > 1:
+                self.stateless_backend = torch_distributed_backend
+                from vllm.distributed.utils import (
+                    create_stateless_process_group,
+                )
+
+                ip = config.parallel_config.data_parallel_master_ip
+                device_group = create_stateless_process_group(
+                    ranks=ranks,
+                    rank=self.rank,
+                    backend=torch_distributed_backend,
+                    host=ip,
+                )
+            else:
+                device_group = torch.distributed.new_group(
+                    ranks, backend=torch_distributed_backend
+                )
             # a group with `gloo` backend, to allow direct coordination between
             # processes through the CPU.
             with suppress_stdout():
@@ -1445,6 +1463,12 @@ def ensure_model_parallel_initialized(
     or ensure tensor-parallel and pipeline-parallel sizes are equal to expected
     values if the model parallel groups are initialized.
     """
+    from vllm.config import get_current_vllm_config
+
+    config = get_current_vllm_config()
+    if config.parallel_config.enable_stateless_pg:
+        backend = get_world_group().stateless_backend
+
     backend = backend or torch.distributed.get_backend(get_world_group().device_group)
     if not model_parallel_is_initialized():
         initialize_model_parallel(

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -636,7 +636,9 @@ def _create_tcp_store_with_retry(
 
         except Exception as e:
             if _should_retry(e, attempt, max_retries):
-                logger.warning("port %s is using，Try next...", current_port)
+                logger.warning(
+                    "Port %s is in use, trying the next available port...", current_port
+                )
                 continue
             else:
                 logger.error("Create TCP store fail: %s", e)

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -6,6 +6,7 @@
 # https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/tensor_parallel/utils.py
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 import dataclasses
+import errno
 import os
 import pickle
 import socket
@@ -508,25 +509,13 @@ def stateless_init_torch_distributed_process_group(
     # Use a PrefixStore to avoid accidental overrides of keys used by
     # different systems (e.g. RPC) in case the store is multi-tenant.
     prefix_store = PrefixStore(init_method, store)
-    try:
-        from vllm.platforms import current_platform
 
-        return current_platform.stateless_init_device_torch_dist_pg(
-            backend=backend,
-            prefix_store=prefix_store,
-            group_rank=group_rank,
-            group_size=group_size,
-            timeout=timeout,
-        )
-    except NotImplementedError:
-        # If platform doesn't implement stateless_init_device_torch_dist_pg, it
-        # will raise a NotImplementedError. In this case, we fall back to gloo.
-        return init_gloo_process_group(
-            prefix_store=prefix_store,
-            group_rank=group_rank,
-            group_size=group_size,
-            timeout=timeout,
-        )
+    return init_gloo_process_group(
+        prefix_store=prefix_store,
+        group_rank=group_rank,
+        group_size=group_size,
+        timeout=timeout,
+    )
 
 
 def stateless_destroy_torch_distributed_process_group(pg: ProcessGroup) -> None:
@@ -543,3 +532,159 @@ def stateless_destroy_torch_distributed_process_group(pg: ProcessGroup) -> None:
         _shutdown_backend(pg)
 
     _unregister_process_group(pg.group_name)
+
+
+def create_stateless_process_group(
+    ranks: list[int],
+    rank: int,
+    backend: str,
+    host: str = "127.0.0.1",
+    base_port: int = 29500,
+    port_range: int = 1500,
+) -> ProcessGroup:
+    """
+    Create a stateless process group for distributed communication.
+
+    This function initializes a TCP store
+    and creates a process group using the specified backend.
+    It handles port conflicts by retrying
+    with different ports if the initial port is unavailable.
+
+    Args:
+        ranks: List of global ranks that should be included in the process group
+        rank: The rank of the current process
+        backend: The distributed backend to use (e.g., 'nccl', 'gloo')
+        host: The host address for the TCP store (default: '127.0.0.1')
+        base_port: The base port number to start from (default: 29500)
+        port_range: The range of ports to try if the initial port is busy
+
+    Returns:
+        A ProcessGroup object if successful,
+        None if the local_rank is not in the ranks list
+    """
+    if not _is_rank_in_group(rank, ranks):
+        return None
+
+    group_rank, group_size = _calculate_group_position(rank, ranks)
+
+    port = _generate_deterministic_port(ranks, base_port, port_range)
+
+    # Attempt to create TCP store with retry mechanism for port conflicts
+    timeout = _get_default_timeout(backend)
+    prefix_store = _create_tcp_store_with_retry(
+        host, port, group_rank, group_size, timeout, ranks
+    )
+
+    # Initialize the process group using the current platform's implementation
+    return _initialize_process_group(
+        backend, prefix_store, group_rank, group_size, timeout
+    )
+
+
+def _is_rank_in_group(rank: int, ranks: list[int]) -> bool:
+    """Generate a deterministic port based on the sorted ranks"""
+    return rank in ranks
+
+
+def _calculate_group_position(rank: int, ranks: list[int]) -> tuple[int, int]:
+    """Calculate group position and size"""
+    group_rank = ranks.index(rank)
+    group_size = len(ranks)
+    return group_rank, group_size
+
+
+def _generate_deterministic_port(
+    ranks: list[int], base_port: int, port_range: int
+) -> int:
+    """Generate a deterministic port based on the sorted ranks"""
+    import hashlib
+
+    ranks_tuple = tuple(sorted(ranks))
+    ranks_hash = hashlib.md5(str(ranks_tuple).encode()).hexdigest()
+    port_offset = int(ranks_hash, 16) % port_range
+    return base_port + port_offset
+
+
+def _create_tcp_store_with_retry(
+    host: str,
+    port: int,
+    group_rank: int,
+    group_size: int,
+    timeout: timedelta,
+    ranks: list[int],
+) -> "PrefixStore":
+    """
+    This function initializes a TCP store and creates a process group.
+    It handles port conflicts by retrying with different ports,
+    if the initial port is unavailable.
+    """
+    max_retries = 100
+
+    for attempt in range(max_retries):
+        try:
+            current_port = port + attempt
+            if current_port > 65535:
+                raise RuntimeError("The number of port exceeds the maximum limit.")
+
+            prefix_store = get_stateless_prefix_store(
+                host, current_port, group_rank, group_size, timeout
+            )
+            logger.info(
+                "Success for group %s Create TCP store %s:%s", ranks, host, current_port
+            )
+            return prefix_store
+
+        except Exception as e:
+            if _should_retry(e, attempt, max_retries):
+                logger.warning("port %s is using，Try next...", current_port)
+                continue
+            else:
+                logger.error("Create TCP store fail: %s", e)
+                raise
+
+    raise RuntimeError("Re-raise exception after all retries fail")
+
+
+def _should_retry(exception: Exception, attempt: int, max_retries: int) -> bool:
+    """Determine whether retry should be performed."""
+    if attempt >= max_retries - 1:
+        return False  # Last attempt, no retry
+    is_port_in_use = False
+    # Retry only for port conflict errors
+
+    if isinstance(exception, OSError) and hasattr(exception, "errno"):
+        is_port_in_use = exception.errno == errno.EADDRINUSE
+    elif isinstance(exception, torch.distributed.DistNetworkError):
+        is_port_in_use = "Address already in use" in str(exception)
+
+    return is_port_in_use
+
+
+def _initialize_process_group(
+    backend: str,
+    prefix_store: "PrefixStore",
+    group_rank: int,
+    group_size: int,
+    timeout: timedelta,
+) -> "ProcessGroup":
+    from vllm.platforms import current_platform
+
+    return current_platform.stateless_init_device_torch_dist_pg(
+        backend=backend,
+        prefix_store=prefix_store,
+        group_rank=group_rank,
+        group_size=group_size,
+        timeout=timeout,
+    )
+
+
+def get_stateless_prefix_store(host, port, rank, world_size, timeout):
+    from vllm.utils.network_utils import get_tcp_uri
+
+    init_method = get_tcp_uri(host, port)
+    store, rank, world_size = next(
+        rendezvous(init_method, rank, world_size, timeout=timeout)
+    )
+    store.set_timeout(timeout)
+    prefix_store = PrefixStore(init_method, store)
+    return prefix_store

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -577,6 +577,7 @@ class EngineArgs:
     kv_offloading_size: float | None = CacheConfig.kv_offloading_size
     kv_offloading_backend: KVOffloadingBackend = CacheConfig.kv_offloading_backend
     tokens_only: bool = False
+    enable_stateless_pg: bool = False
 
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`
@@ -893,6 +894,9 @@ class EngineArgs:
         parallel_group.add_argument("--worker-cls", **parallel_kwargs["worker_cls"])
         parallel_group.add_argument(
             "--worker-extension-cls", **parallel_kwargs["worker_extension_cls"]
+        )
+        parallel_group.add_argument(
+            "--enable-stateless-pg", **parallel_kwargs["enable_stateless_pg"]
         )
 
         # KV cache arguments
@@ -1621,6 +1625,7 @@ class EngineArgs:
             cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
             _api_process_count=self._api_process_count,
             _api_process_rank=self._api_process_rank,
+            enable_stateless_pg=self.enable_stateless_pg,
         )
 
         speculative_config = self.create_speculative_config(

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -6,10 +6,12 @@ pynvml. However, it should not initialize cuda context.
 
 import os
 from collections.abc import Callable
+from datetime import timedelta
 from functools import cache, wraps
 from typing import TYPE_CHECKING, Optional, TypeVar
 
 import torch
+from torch.distributed import PrefixStore, ProcessGroup
 from typing_extensions import ParamSpec
 
 # import custom ops, trigger op registration
@@ -572,6 +574,75 @@ class NvmlCudaPlatform(CudaPlatformBase):
                     "avoid unexpected behavior.",
                     ", ".join(device_names),
                 )
+
+    @classmethod
+    def stateless_init_device_torch_dist_pg(
+        cls,
+        backend: str,
+        prefix_store: "PrefixStore",
+        group_rank: int,
+        group_size: int,
+        timeout: timedelta,
+        **kwargs,
+    ) -> "ProcessGroup":
+        """
+        Initialize a stateless NCCL process group for CUDA devices.
+
+        This method creates a ProcessGroup with the specified backend configuration,
+        typically used for GPU communication. It sets up the necessary backend
+        options and registers the backend with the process group.
+
+        Args:
+            backend: The distributed backend to use (e.g., 'nccl')
+            prefix_store: The prefix store for distributed coordination
+            group_rank: The rank of the current process within the group
+            group_size: The total number of processes in the group
+            timeout: Maximum time to wait for the operation to complete
+            **kwargs: Additional backend-specific options
+
+        warning:
+        Uses internal PyTorch API (torch._C._distributed_c10d.ProcessGroupNCCL)
+        which may change in future PyTorch versions. Compatibility should be
+        verified with each PyTorch upgrade.
+
+        Compatibility Risk:
+        - High risk of breakage in PyTorch 2.4+
+        - No semantic versioning guarantees
+        - Requires testing with new PyTorch releases
+
+        Returns:
+            A ProcessGroup object configured with the specified backend
+        """
+
+        # INTERNAL API USAGE - COMPATIBILITY RISK
+        # This internal import is necessary for stateless process group functionality
+        # but carries compatibility risks. Monitor PyTorch release notes for changes.
+        # TODO: Migrate to public API when available in future PyTorch versions
+        from torch._C._distributed_c10d import ProcessGroupNCCL
+
+        pg = ProcessGroup(prefix_store, group_rank, group_size)
+
+        backend_options = ProcessGroupNCCL.Options()
+        backend_options._timeout = timeout
+
+        device = torch.device("cuda")
+        if hasattr(backend_options, "_device"):
+            backend_options._device = device
+
+        # Apply high-priority stream setting if provided
+        if "is_high_priority_stream" in kwargs:
+            backend_options.is_high_priority_stream = kwargs["is_high_priority_stream"]
+
+        backend_class = ProcessGroupNCCL(
+            prefix_store, group_rank, group_size, backend_options
+        )
+
+        backend_class._set_sequence_number_for_group()
+
+        backend_type = ProcessGroup.BackendType.CUSTOM
+        pg._register_backend(device, backend_type, backend_class)
+
+        return pg
 
 
 class NonNvmlCudaPlatform(CudaPlatformBase):


### PR DESCRIPTION


Replace torch.distributed.new_group with stateless process group initialization to address resource management issues in distributed training.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

