### PR TITLE
Fault Tolerant EP: Implement fault-report

### DIFF
--- a/tests/v1/engine/test_engine_core_sentinel.py
+++ b/tests/v1/engine/test_engine_core_sentinel.py
@@ -3,22 +3,14 @@
 
 import queue
 import threading
-import time
-import uuid
 
-import pytest
 import zmq
-from msgspec import msgpack
 
 from vllm.config import FaultToleranceConfig, ParallelConfig, VllmConfig
-from vllm.utils.network_utils import make_zmq_socket
-from vllm.v1.engine import FaultToleranceRequest, FaultToleranceResult
 from vllm.v1.engine.core import (
     EngineCoreSentinel,
-    EngineLoopPausedError,
 )
 
-# todo: check if this file has been updated with the new changes
 CLIENT_CMD_ADDR = "tcp://127.0.0.1:8844"
 WORKER_CMD_ADDR = "tcp://127.0.0.1:8845"
 ENGINE_FAULT_SOCKET_ADDR = "tcp://127.0.0.1:8846"
@@ -41,11 +33,7 @@ def create_engine_core_sentinel(
     return EngineCoreSentinel(
         engine_index=0,
         fault_signal_q=fault_signal_q,
-        cmd_q=queue.Queue(),
         busy_loop_active=busy_loop_active,
-        engine_input_q=queue.Queue(),
-        client_cmd_addr=CLIENT_CMD_ADDR,
-        worker_cmd_addr=WORKER_CMD_ADDR,
         engine_fault_socket_addr=ENGINE_FAULT_SOCKET_ADDR,
         sentinel_identity=SENTINEL_IDENTITY,
         vllm_config=vllm_cfg,
@@ -61,94 +49,8 @@ def test_engine_core_sentinel_initialization():
     assert sentinel.engine_index == 0
     assert sentinel.tp_size == 1
     assert sentinel.pp_size == 1
-    assert not sentinel.communicator_aborted
     assert sentinel.engine_running is True
 
     assert sentinel.engine_fault_socket.type == zmq.DEALER
-    assert sentinel.upstream_cmd_socket.type == zmq.DEALER
-    assert sentinel.downstream_cmd_socket.type == zmq.ROUTER
 
     sentinel.shutdown()
-
-
-@pytest.mark.parametrize("instruction", ["pause", "retry"])
-def test_run_handle_instruction(instruction):
-    fault_signal_q: queue.Queue = queue.Queue()
-    busy_loop_active = threading.Event()
-
-    client_socket = make_zmq_socket(
-        ctx=zmq.Context(), path=CLIENT_CMD_ADDR, socket_type=zmq.ROUTER, bind=True
-    )
-
-    time.sleep(0.1)
-
-    sentinel = create_engine_core_sentinel(fault_signal_q, busy_loop_active)
-    time.sleep(0.1)
-
-    ctx = zmq.Context()
-    worker_cmd_socket = ctx.socket(zmq.DEALER)
-    worker_cmd_socket.setsockopt(zmq.IDENTITY, b"PP0_TP0")
-    worker_cmd_socket.connect(WORKER_CMD_ADDR)
-
-    def mock_worker_receiver(cmd_socket):
-        time.sleep(0.1)
-        if not cmd_socket.poll(timeout=2000):
-            pytest.fail("Timeout waiting for command from sentinel")
-        parts = cmd_socket.recv_multipart()
-        # DEALER receives messages in the form [empty_frame, msg_bytes]
-        empty_frame = None
-        msg_bytes = None
-        if len(parts) == 2:
-            empty_frame, msg_bytes = parts
-        elif len(parts) == 3:
-            # tolerate an extra identity frame if present
-            _, empty_frame, msg_bytes = parts
-        else:
-            pytest.fail(f"Unexpected multipart length: {len(parts)}")
-
-        assert empty_frame == b""
-        ft_req = msgpack.decode(msg_bytes, type=FaultToleranceRequest)
-        assert ft_req.instruction == instruction
-
-        # Reply with a msgpack-encoded FaultToleranceResult
-        ft_res = FaultToleranceResult(request_id=ft_req.request_id, success=True)
-        cmd_socket.send_multipart([b"", msgpack.encode(ft_res)])
-
-    param = {"timeout": 3}
-    if instruction == "pause":
-        param["soft_pause"] = True
-    elif instruction == "retry":
-        param["new_stateless_dp_group_port"] = 23456
-
-    # Build a FaultToleranceRequest and send as msgpack
-    req_id = str(uuid.uuid4())
-    ft_request = FaultToleranceRequest(
-        request_id=req_id, instruction=instruction, params=param
-    )
-    client_socket.send_multipart([SENTINEL_IDENTITY, b"", msgpack.encode(ft_request)])
-
-    fault_signal_q.put(EngineLoopPausedError(Exception("test error")))
-    if instruction == "retry":
-        busy_loop_active.set()
-
-    threading.Thread(
-        target=mock_worker_receiver, args=(worker_cmd_socket,), daemon=True
-    ).start()
-
-    time.sleep(0.1)
-    if not client_socket.poll(timeout=2000):
-        pytest.fail("Timeout waiting for response from sentinel")
-    identity, _, msg_bytes = client_socket.recv_multipart()
-
-    # The ROUTER identity frame indicates who replied
-    assert identity == SENTINEL_IDENTITY
-    ft_res = msgpack.decode(msg_bytes, type=FaultToleranceResult)
-    assert ft_res.request_id == req_id
-    assert ft_res.success
-
-    time.sleep(0.1)
-
-    client_socket.close()
-    worker_cmd_socket.close()
-    sentinel.shutdown()
-    ctx.term()

--- a/vllm/config/fault_tolerance.py
+++ b/vllm/config/fault_tolerance.py
@@ -16,10 +16,6 @@ class FaultToleranceConfig:
     such as scaling down fault DPEngineCore.
     """
 
-    shutdown_on_fault_tolerance_failure: bool = False
-    """Whether to shut down vLLM when a fault tolerance action fails.
-    """
-
     engine_recovery_timeout: int = 60
     """Timeout (in seconds) to wait for error handling instructions
     before raising an exception. If the EngineCore encounters an
@@ -41,13 +37,6 @@ class FaultToleranceConfig:
     gloo_comm_timeout: int = 30
     """
     The timeout for gloo communication.
-    """
-
-    worker_cmd_addr: str | None = None
-    """
-    ZMQ address used by EngineCoreSentinel to dispatch instructions to 
-    WorkerSentinel instances. This address is assigned dynamically during 
-    runtime.
     """
 
     def compute_hash(self) -> str:

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -236,7 +236,7 @@ class PyNcclCommunicator:
                 cudaStream_t(stream.cuda_stream),
             )
             split_offset += split_size
-        self.nccl.ncclGroupEnd(self.comm)
+        self.nccl.ncclGroupEnd()
 
     def reduce_scatter(
         self,
@@ -301,7 +301,7 @@ class PyNcclCommunicator:
                 cudaStream_t(stream.cuda_stream),
             )
             split_offset += split_size
-        self.nccl.ncclGroupEnd(self.comm)
+        self.nccl.ncclGroupEnd()
 
     def send(self, tensor: torch.Tensor, dst: int, stream=None):
         if self.disabled:
@@ -369,10 +369,7 @@ class PyNcclCommunicator:
         self.nccl.ncclGroupStart()
 
     def group_end(self):
-        self.nccl.ncclGroupEnd(self.comm)
-
-    def nccl_abort_comm(self):
-        self.nccl.ncclCommAbort(self.comm)
+        self.nccl.ncclGroupEnd()
 
     def register_comm_window(self, tensor: torch.Tensor):
         return self.nccl.ncclCommWindowRegister(

--- a/vllm/distributed/device_communicators/pynccl_wrapper.py
+++ b/vllm/distributed/device_communicators/pynccl_wrapper.py
@@ -143,15 +143,6 @@ class NCCLLibrary:
         Function("ncclGetVersion", ncclResult_t, [ctypes.POINTER(ctypes.c_int)]),
         # ncclResult_t ncclGetUniqueId(ncclUniqueId* uniqueId);
         Function("ncclGetUniqueId", ncclResult_t, [ctypes.POINTER(ncclUniqueId)]),
-        # ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError)
-        Function(
-            "ncclCommGetAsyncError",
-            ncclResult_t,
-            [
-                ncclComm_t,
-                ctypes.POINTER(ncclResult_t),
-            ],
-        ),
         # ncclResult_t  ncclCommInitRank(
         #   ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank);
         # note that ncclComm_t is a pointer type, so the first argument
@@ -290,8 +281,6 @@ class NCCLLibrary:
         # it is better not to call it at all.
         # ncclResult_t  ncclCommDestroy(ncclComm_t comm);
         Function("ncclCommDestroy", ncclResult_t, [ncclComm_t]),
-        # ncclResult_t ncclCommAbort(ncclComm_t comm)
-        Function("ncclCommAbort", ncclResult_t, [ncclComm_t]),
         # ncclResult_t ncclGroupStart();
         Function("ncclGroupStart", ncclResult_t, []),
         # ncclResult_t ncclGroupEnd();
@@ -378,32 +367,10 @@ class NCCLLibrary:
     def ncclGetErrorString(self, result: ncclResult_t) -> str:
         return self._funcs["ncclGetErrorString"](result).decode("utf-8")
 
-    def NCCL_CHECK(self, result: ncclResult_t, comm: ncclComm_t | None = None) -> None:
-        ncclSuccess = 0
-        ncclInProgress = 7
-
-        if result == ncclSuccess:
-            return
-
-        # Handle non-blocking communicators
-        if result == ncclInProgress:
-            if comm is None:
-                raise RuntimeError(
-                    "NCCL_CHECK: ncclInProgress returned but no communicator "
-                    "provided (required for non-blocking NCCL checks)."
-                )
-            while True:
-                result = self.ncclCommGetAsyncError(comm)
-                result_value = result.value
-                if result_value == ncclSuccess:
-                    # Operation has completed successfully
-                    return
-                if result_value != ncclInProgress:
-                    # Now a definite error occurred
-                    break
-
-        error_str = self.ncclGetErrorString(result)
-        raise RuntimeError(f"NCCL_CHECK failed: {error_str} (code={result})")
+    def NCCL_CHECK(self, result: ncclResult_t) -> None:
+        if result != 0:
+            error_str = self.ncclGetErrorString(result)
+            raise RuntimeError(f"NCCL error: {error_str}")
 
     def ncclGetRawVersion(self) -> int:
         version = ctypes.c_int()
@@ -424,11 +391,6 @@ class NCCLLibrary:
         self.NCCL_CHECK(self._funcs["ncclGetUniqueId"](ctypes.byref(unique_id)))
         return unique_id
 
-    def ncclCommGetAsyncError(self, comm: ncclComm_t) -> ncclResult_t:
-        async_error = ncclResult_t()
-        self._funcs["ncclCommGetAsyncError"](comm, ctypes.byref(async_error))
-        return async_error
-
     def unique_id_from_bytes(self, data: bytes) -> ncclUniqueId:
         if len(data) != 128:
             raise ValueError(
@@ -445,8 +407,7 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclCommInitRank"](
                 ctypes.byref(comm), world_size, unique_id, rank
-            ),
-            comm,
+            )
         )
         return comm
 
@@ -468,8 +429,7 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclAllReduce"](
                 sendbuff, recvbuff, count, datatype, op, comm, stream
-            ),
-            comm,
+            )
         )
 
     def ncclReduce(
@@ -491,8 +451,7 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclReduce"](
                 sendbuff, recvbuff, count, datatype, op, root, comm, stream
-            ),
-            comm,
+            )
         )
 
     def ncclReduceScatter(
@@ -513,8 +472,7 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclReduceScatter"](
                 sendbuff, recvbuff, count, datatype, op, comm, stream
-            ),
-            comm,
+            )
         )
 
     def ncclAllGather(
@@ -533,8 +491,7 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclAllGather"](
                 sendbuff, recvbuff, count, datatype, comm, stream
-            ),
-            comm,
+            )
         )
 
     def ncclSend(
@@ -547,7 +504,7 @@ class NCCLLibrary:
         stream: cudaStream_t,
     ) -> None:
         self.NCCL_CHECK(
-            self._funcs["ncclSend"](sendbuff, count, datatype, dest, comm, stream), comm
+            self._funcs["ncclSend"](sendbuff, count, datatype, dest, comm, stream)
         )
 
     def ncclRecv(
@@ -560,7 +517,7 @@ class NCCLLibrary:
         stream: cudaStream_t,
     ) -> None:
         self.NCCL_CHECK(
-            self._funcs["ncclRecv"](recvbuff, count, datatype, src, comm, stream), comm
+            self._funcs["ncclRecv"](recvbuff, count, datatype, src, comm, stream)
         )
 
     def ncclBroadcast(
@@ -576,21 +533,17 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclBroadcast"](
                 sendbuff, recvbuff, count, datatype, root, comm, stream
-            ),
-            comm,
+            )
         )
 
     def ncclCommDestroy(self, comm: ncclComm_t) -> None:
-        self.NCCL_CHECK(self._funcs["ncclCommDestroy"](comm), comm)
-
-    def ncclCommAbort(self, comm: ncclComm_t) -> None:
-        self.NCCL_CHECK(self._funcs["ncclCommAbort"](comm), comm)
+        self.NCCL_CHECK(self._funcs["ncclCommDestroy"](comm))
 
     def ncclGroupStart(self) -> None:
         self.NCCL_CHECK(self._funcs["ncclGroupStart"]())
 
-    def ncclGroupEnd(self, comm) -> None:
-        self.NCCL_CHECK(self._funcs["ncclGroupEnd"](), comm)
+    def ncclGroupEnd(self) -> None:
+        self.NCCL_CHECK(self._funcs["ncclGroupEnd"]())
 
     def ncclCommWindowRegister(
         self, comm: ncclComm_t, buff: buffer_type, size: int, win_flags: int
@@ -599,13 +552,12 @@ class NCCLLibrary:
         self.NCCL_CHECK(
             self._funcs["ncclCommWindowRegister"](
                 comm, buff, size, ctypes.byref(window), win_flags
-            ),
-            comm,
+            )
         )
         return window
 
     def ncclCommWindowDeregister(self, comm: ncclComm_t, window: ncclWindow_t) -> None:
-        self.NCCL_CHECK(self._funcs["ncclCommWindowDeregister"](comm, window), comm)
+        self.NCCL_CHECK(self._funcs["ncclCommWindowDeregister"](comm, window))
 
 
 __all__ = [

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -25,7 +25,6 @@ If you only need to use the distributed environment without model/pipeline
 
 import contextlib
 import gc
-import os
 import pickle
 import weakref
 from collections import namedtuple
@@ -44,7 +43,6 @@ import torch.distributed._symmetric_memory
 from torch.distributed import Backend, ProcessGroup
 
 import vllm.envs as envs
-from vllm.config import FaultToleranceConfig
 from vllm.distributed.device_communicators.base_device_communicator import (
     DeviceCommunicatorBase,
 )
@@ -320,7 +318,6 @@ class GroupCoordinator:
         use_device_communicator: bool,  # whether to use device communicator
         use_message_queue_broadcaster: bool = False,
         group_name: str | None = None,
-        fault_tolerance_config: FaultToleranceConfig | None = None,
     ):
         group_name = group_name or "anonymous"
         self.unique_name = _get_unique_name(group_name)
@@ -332,31 +329,14 @@ class GroupCoordinator:
         self_device_group = None
         self_cpu_group = None
 
-        gloo_comm_timeout = None
-        options = None
-        if torch_distributed_backend == "nccl":
-            options = torch._C._distributed_c10d.ProcessGroupNCCL.Options()
-            if (
-                fault_tolerance_config is not None
-                and fault_tolerance_config.enable_fault_tolerance
-            ):
-                gloo_comm_timeout = timedelta(
-                    seconds=fault_tolerance_config.gloo_comm_timeout
-                )
-                # need to set communicators as nonblocking to abort safely
-                options.config.blocking = 0
-                os.environ["NCCL_COMM_BLOCKING"] = "0"
-
         for ranks in group_ranks:
             device_group = torch.distributed.new_group(
-                ranks, backend=torch_distributed_backend, pg_options=options
+                ranks, backend=torch_distributed_backend
             )
             # a group with `gloo` backend, to allow direct coordination between
             # processes through the CPU.
             with suppress_stdout():
-                cpu_group = torch.distributed.new_group(
-                    ranks, backend="gloo", timeout=gloo_comm_timeout
-                )
+                cpu_group = torch.distributed.new_group(ranks, backend="gloo")
             if self.rank in ranks:
                 self.ranks = ranks
                 self.world_size = len(ranks)
@@ -1148,10 +1128,7 @@ def get_inner_dp_world_group() -> GroupCoordinator:
 
 
 def init_world_group(
-    ranks: list[int],
-    local_rank: int,
-    backend: str,
-    fault_tolerance_config: FaultToleranceConfig | None = None,
+    ranks: list[int], local_rank: int, backend: str
 ) -> GroupCoordinator:
     return GroupCoordinator(
         group_ranks=[ranks],
@@ -1159,7 +1136,6 @@ def init_world_group(
         torch_distributed_backend=backend,
         use_device_communicator=False,
         group_name="world",
-        fault_tolerance_config=fault_tolerance_config,
     )
 
 
@@ -1170,7 +1146,6 @@ def init_model_parallel_group(
     use_message_queue_broadcaster: bool = False,
     group_name: str | None = None,
     use_device_communicator: bool = True,
-    fault_tolerance_config: FaultToleranceConfig | None = None,
 ) -> GroupCoordinator:
     return GroupCoordinator(
         group_ranks=group_ranks,
@@ -1179,7 +1154,6 @@ def init_model_parallel_group(
         use_device_communicator=use_device_communicator,
         use_message_queue_broadcaster=use_message_queue_broadcaster,
         group_name=group_name,
-        fault_tolerance_config=fault_tolerance_config,
     )
 
 
@@ -1250,35 +1224,6 @@ def get_pcp_group() -> GroupCoordinator:
     return _PCP
 
 
-def get_all_model_groups() -> list[GroupCoordinator]:
-    group_list = []
-    global _TP
-    if _TP:
-        group_list.append(_TP)
-
-    global _PP
-    if _PP:
-        group_list.append(_PP)
-
-    global _DCP
-    if _DCP:
-        group_list.append(_DCP)
-
-    global _DP
-    if _DP:
-        group_list.append(_DP)
-
-    global _EP
-    if _EP:
-        group_list.append(_EP)
-
-    global _PCP
-    if _PCP:
-        group_list.append(_PCP)
-
-    return group_list
-
-
 @contextmanager
 def graph_capture(device: torch.device):
     """
@@ -1316,7 +1261,6 @@ def init_distributed_environment(
     local_rank: int = -1,
     backend: str = "nccl",
     timeout: timedelta | None = None,
-    fault_tolerance_config: FaultToleranceConfig | None = None,
 ):
     logger.debug(
         "world_size=%d rank=%d local_rank=%d distributed_init_method=%s backend=%s",
@@ -1399,9 +1343,7 @@ def init_distributed_environment(
     global _WORLD, _NODE_COUNT, _INNER_DP_WORLD
     if _WORLD is None:
         ranks = list(range(torch.distributed.get_world_size()))
-        _WORLD = init_world_group(
-            ranks, local_rank, backend, fault_tolerance_config=fault_tolerance_config
-        )
+        _WORLD = init_world_group(ranks, local_rank, backend)
         if config is not None and config.parallel_config.nnodes > 1:
             _NODE_COUNT = config.parallel_config.nnodes
         else:
@@ -1436,7 +1378,6 @@ def initialize_model_parallel(
     prefill_context_model_parallel_size: int = 1,
     decode_context_model_parallel_size: int | None = 1,
     backend: str | None = None,
-    fault_tolerance_config: FaultToleranceConfig | None = None,
 ) -> None:
     """
     Initialize model parallel groups.
@@ -1504,7 +1445,6 @@ def initialize_model_parallel(
         backend,
         use_message_queue_broadcaster=True,
         group_name="tp",
-        fault_tolerance_config=fault_tolerance_config,
     )
 
     # Build the DCP model-parallel groups.
@@ -1522,7 +1462,6 @@ def initialize_model_parallel(
         backend,
         use_message_queue_broadcaster=True,
         group_name="dcp",
-        fault_tolerance_config=fault_tolerance_config,
     )
 
     global _PCP
@@ -1545,11 +1484,7 @@ def initialize_model_parallel(
     )
     group_ranks = [x.tolist() for x in group_ranks]
     _PP = init_model_parallel_group(
-        group_ranks,
-        get_world_group().local_rank,
-        backend,
-        group_name="pp",
-        fault_tolerance_config=fault_tolerance_config,
+        group_ranks, get_world_group().local_rank, backend, group_name="pp"
     )
 
     global _DP
@@ -1557,11 +1492,7 @@ def initialize_model_parallel(
     group_ranks = all_ranks.transpose(1, 4).reshape(-1, data_parallel_size).unbind(0)
     group_ranks = [x.tolist() for x in group_ranks]
     _DP = init_model_parallel_group(
-        group_ranks,
-        get_world_group().local_rank,
-        backend,
-        group_name="dp",
-        fault_tolerance_config=fault_tolerance_config,
+        group_ranks, get_world_group().local_rank, backend, group_name="dp"
     )
 
     global _EP
@@ -1580,11 +1511,7 @@ def initialize_model_parallel(
         )
         group_ranks = [x.tolist() for x in group_ranks]
         _EP = init_model_parallel_group(
-            group_ranks,
-            get_world_group().local_rank,
-            backend,
-            group_name="ep",
-            fault_tolerance_config=fault_tolerance_config,
+            group_ranks, get_world_group().local_rank, backend, group_name="ep"
         )
 
         # Create EPLB group with the same ranks as EP if EPLB is enabled.
@@ -1626,7 +1553,6 @@ def ensure_model_parallel_initialized(
     prefill_context_model_parallel_size: int = 1,
     decode_context_model_parallel_size: int | None = 1,
     backend: str | None = None,
-    fault_tolerance_config: FaultToleranceConfig | None = None,
 ) -> None:
     """Helper to initialize model parallel groups if they are not initialized,
     or ensure tensor-parallel and pipeline-parallel sizes are equal to expected
@@ -1640,7 +1566,6 @@ def ensure_model_parallel_initialized(
             prefill_context_model_parallel_size,
             decode_context_model_parallel_size,
             backend,
-            fault_tolerance_config=fault_tolerance_config,
         )
         return
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -590,9 +590,6 @@ class EngineArgs:
     internal_fault_report_port: int = FaultToleranceConfig.internal_fault_report_port
     external_fault_notify_port: int = FaultToleranceConfig.external_fault_notify_port
     gloo_comm_timeout: int = FaultToleranceConfig.gloo_comm_timeout
-    shutdown_on_fault_tolerance_failure: bool = (
-        FaultToleranceConfig.shutdown_on_fault_tolerance_failure
-    )
 
     kv_offloading_size: float | None = CacheConfig.kv_offloading_size
     kv_offloading_backend: KVOffloadingBackend = CacheConfig.kv_offloading_backend
@@ -1249,10 +1246,6 @@ class EngineArgs:
             **fault_tolerance_kwargs["enable_fault_tolerance"],
         )
         fault_tolerance_group.add_argument(
-            "--shutdown-on-fault-tolerance-failure",
-            **fault_tolerance_kwargs["shutdown_on_fault_tolerance_failure"],
-        )
-        fault_tolerance_group.add_argument(
             "--engine-recovery-timeout",
             **fault_tolerance_kwargs["engine_recovery_timeout"],
         )
@@ -1831,7 +1824,6 @@ class EngineArgs:
 
         fault_tolerance_config = FaultToleranceConfig(
             enable_fault_tolerance=self.enable_fault_tolerance,
-            shutdown_on_fault_tolerance_failure=self.shutdown_on_fault_tolerance_failure,
             engine_recovery_timeout=self.engine_recovery_timeout,
             internal_fault_report_port=self.internal_fault_report_port,
             external_fault_notify_port=self.external_fault_notify_port,

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -19,11 +19,7 @@ from vllm.renderers import BaseRenderer
 from vllm.renderers.inputs import DictPrompt, TokPrompt
 from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
-from vllm.v1.engine import (
-    EngineCoreRequest,
-    FaultToleranceRequest,
-    FaultToleranceResult,
-)
+from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.input_processor import InputProcessor
 
 if TYPE_CHECKING:
@@ -205,12 +201,6 @@ class EngineClient(ABC):
         kwargs: dict | None = None,
     ):
         """Perform a collective RPC call to the given path."""
-        raise NotImplementedError
-
-    async def handle_fault(
-        self, fault_tolerance_request: FaultToleranceRequest
-    ) -> FaultToleranceResult:
-        """send fault tolerance instruction to the engine"""
         raise NotImplementedError
 
     async def get_fault_info(self):

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -15,7 +15,7 @@ from argparse import Namespace
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 import vllm.envs as envs
@@ -29,7 +29,6 @@ from vllm.usage.usage_lib import UsageContext
 from vllm.utils import random_uuid
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.system_utils import set_ulimit
-from vllm.v1.engine import FaultToleranceRequest
 from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger("vllm.entrypoints.api_server")
@@ -55,54 +54,6 @@ async def generate(request: Request) -> Response:
     """
     request_dict = await request.json()
     return await _generate(request_dict, raw_request=request)
-
-
-@app.post("/fault_tolerance/apply")
-async def process_fault_tolerance_instruction(request: Request) -> Response:
-    """Apply fault tolerance instructions to the engine.
-
-    This endpoint handles fault recovery operations such as retrying operations.
-
-    The request should be a JSON object with the following fields:
-    - fault_tolerance_instruction: The name of fault tolerance method.
-    - fault_tolerance_timeout: Timeout in seconds for the operation to complete.
-    - fault_tolerance_params: dict, optional. Additional dynamic parameters for
-    the fault tolerance operation.
-    """
-    request_dict = await request.json()
-
-    fault_tolerance_instruction = request_dict.get("fault_tolerance_instruction")
-    fault_tolerance_timeout = request_dict.get("fault_tolerance_timeout")
-    kwargs = request_dict.get("fault_tolerance_params", {})
-    assert engine is not None
-    kwargs["timeout"] = fault_tolerance_timeout
-    ft_request = FaultToleranceRequest(
-        request_id=random_uuid(),
-        instruction=fault_tolerance_instruction,
-        params=kwargs,
-    )
-    ft_result = await engine.handle_fault(ft_request)
-    success, reason = ft_result.success, ft_result.reason
-    if success:
-        return JSONResponse(
-            status_code=200,
-            content={"message": "Instruction executed successfully."},
-        )
-
-    logger.error("Fault tolerance operation failed. Shutting down the engine.")
-    engine.shutdown()
-    raise HTTPException(
-        status_code=400,
-        detail=f"Instruction execution failed. Reason: {reason}",
-    )
-
-
-@app.get("/fault_tolerance/status")
-async def get_fault_info() -> Response:
-    """Health check."""
-    assert engine is not None
-    engine_status_dict = await engine.get_fault_info()
-    return Response(json.dumps(engine_status_dict), status_code=200)
 
 
 @with_cancellation

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -267,8 +267,6 @@ def run_multi_api_server(args: argparse.Namespace):
             if coordinator
             else None,
             engine_fault_socket_addr=addresses.engine_fault_socket_addr,
-            client_sentinel_cmd_addr=addresses.client_sentinel_cmd_addr,
-            engine_core_sentinel_cmd_addr=addresses.engine_core_sentinel_cmd_addr,
             engine_core_sentinel_identities=addresses.engine_core_sentinel_identities,
             fault_state_pub_socket_addr=addresses.fault_state_pub_socket_addr,
         )

--- a/vllm/entrypoints/serve/fault_tolerance/api_router.py
+++ b/vllm/entrypoints/serve/fault_tolerance/api_router.py
@@ -2,18 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
-import json
-import uuid
-from http import HTTPStatus
-
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from vllm.engine.protocol import EngineClient
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
-from vllm.entrypoints.openai.utils import validate_json_request
 from vllm.logger import init_logger
-from vllm.v1.engine import FaultToleranceRequest
 
 logger = init_logger(__name__)
 
@@ -23,79 +16,6 @@ def engine_client(request: Request) -> EngineClient:
 
 
 router = APIRouter()
-
-
-@router.post(
-    "/fault_tolerance/apply",
-    dependencies=[Depends(validate_json_request)],
-    responses={
-        HTTPStatus.OK.value: {"model": dict},
-        HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
-        HTTPStatus.REQUEST_TIMEOUT.value: {"model": ErrorResponse},
-        HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
-    },
-)
-async def process_fault_tolerance_instruction(raw_request: Request):
-    try:
-        body = await raw_request.json()
-    except json.JSONDecodeError as e:
-        raise HTTPException(status_code=400, detail="Invalid JSON format") from e
-
-    client = engine_client(raw_request)
-
-    fault_tolerance_instruction = body.get("fault_tolerance_instruction")
-    fault_tolerance_timeout = body.get("fault_tolerance_timeout")
-    fault_tolerance_params = body.get("fault_tolerance_params", {})
-
-    if fault_tolerance_instruction is None or fault_tolerance_timeout is None:
-        raise HTTPException(
-            status_code=400,
-            detail="Both 'fault_tolerance_instruction' and "
-            "'fault_tolerance_timeout' are required.",
-        )
-
-    if not isinstance(fault_tolerance_instruction, str):
-        raise HTTPException(
-            status_code=400, detail="'fault_tolerance_instruction' must be a string."
-        )
-    # Supported instructions: ["pause", "retry"].
-    # More instruction types may be added in future updates.
-    elif fault_tolerance_instruction not in ["pause", "retry"]:
-        raise HTTPException(
-            status_code=400, detail="Invalid 'fault_tolerance_instruction' value."
-        )
-
-    if not isinstance(fault_tolerance_timeout, int) or fault_tolerance_timeout <= 0:
-        raise HTTPException(
-            status_code=400,
-            detail="'fault_tolerance_timeout' must be a positive integer.",
-        )
-    try:
-        fault_tolerance_params["timeout"] = fault_tolerance_timeout
-        ft_request = FaultToleranceRequest(
-            str(uuid.uuid4()), fault_tolerance_instruction, fault_tolerance_params
-        )
-
-        ft_result = await client.handle_fault(ft_request)
-        success, reason = ft_result.success, ft_result.reason
-        if success:
-            return JSONResponse(
-                {
-                    "message": "Instruction executed successfully.",
-                }
-            )
-        else:
-            raise HTTPException(
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
-                detail=f"Instruction execution failed. Reason: {reason}",
-            )
-
-    except Exception as e:
-        logger.error("Failed to handle fault: %s", e)
-        raise HTTPException(
-            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
-            detail="Failed to handle fault.",
-        ) from e
 
 
 @router.get("/fault_tolerance/status")

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -80,19 +80,6 @@ class SchedulerInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def preempt_request(
-        self,
-        request: "Request",
-        timestamp: float,
-    ) -> None:
-        """Preempt a request and put it back to the waiting queue.
-
-        NOTE: The request should be popped from the running queue outside of this
-        method.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     def update_from_output(
         self,
         scheduler_output: "SchedulerOutput",

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -477,7 +477,7 @@ class Scheduler(SchedulerInterface):
                     else:
                         preempted_req = self.running.pop()
 
-                    self.preempt_request(preempted_req, scheduled_timestamp)
+                    self._preempt_request(preempted_req, scheduled_timestamp)
                     preempted_reqs.append(preempted_req)
                     if preempted_req == request:
                         # No more request to preempt. Cannot schedule this request.
@@ -907,7 +907,7 @@ class Scheduler(SchedulerInterface):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
 
-    def preempt_request(self, request: Request, timestamp: float) -> None:
+    def _preempt_request(self, request: Request, timestamp: float) -> None:
         """Preempt a request and put it back to the waiting queue.
 
         NOTE: The request should be popped from the running queue outside of this
@@ -1801,7 +1801,7 @@ class Scheduler(SchedulerInterface):
             # running queue in FIFO order.
             while self.running:
                 request = self.running.pop()
-                self.preempt_request(request, timestamp)
+                self._preempt_request(request, timestamp)
                 # NOTE(zhuohan): For async scheduling, we need to discard the latest
                 # output token on the fly to avoid a redundant repetitive output token.
                 request.num_output_placeholders = 0

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -227,7 +227,6 @@ class EngineCoreRequestType(enum.Enum):
     UTILITY = b"\x03"
     # Sentinel used within EngineCoreProc.
     EXECUTOR_FAILED = b"\x04"
-    PAUSE = b"\x05"
 
 
 class ReconfigureDistributedRequest(msgspec.Struct):
@@ -245,26 +244,6 @@ class ReconfigureRankType(enum.IntEnum):
 
     KEEP_CURRENT_RANK = -1
     SHUTDOWN_CURRENT_RANK = -2
-
-
-class FaultToleranceRequest(msgspec.Struct):
-    """
-    Request for fault tolerance instructions, used in the fault tolerance protocol.
-    """
-
-    request_id: str
-    instruction: str
-    params: dict[str, Any]
-
-
-class FaultToleranceResult(msgspec.Struct):
-    """
-    Result of applying fault tolerance instructions.
-    """
-
-    request_id: str
-    success: bool
-    reason: str | None = None
 
 
 class EngineStatusType(enum.IntEnum):

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -38,12 +38,7 @@ from vllm.transformers_utils.config import maybe_register_config_serialize_by_va
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.async_utils import cancel_task_threadsafe
 from vllm.utils.collection_utils import as_list
-from vllm.v1.engine import (
-    EngineCoreRequest,
-    FaultToleranceRequest,
-    FaultToleranceResult,
-    PauseMode,
-)
+from vllm.v1.engine import EngineCoreRequest, PauseMode
 from vllm.v1.engine.core_client import EngineCoreClient
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
 from vllm.v1.engine.input_processor import InputProcessor
@@ -1003,12 +998,6 @@ class AsyncLLM(EngineClient):
                 engine_idxs=list(range(new_data_parallel_size)),
                 custom_stat_loggers=None,
             )
-
-    async def handle_fault(
-        self, fault_tolerance_request: FaultToleranceRequest
-    ) -> FaultToleranceResult:
-        """send fault tolerance instruction to the engine"""
-        return await self.engine_core.handle_fault(fault_tolerance_request)
 
     async def get_fault_info(self):
         """report exception in engine core"""

--- a/vllm/v1/engine/base_sentinel.py
+++ b/vllm/v1/engine/base_sentinel.py
@@ -1,16 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import time
 from abc import abstractmethod
 
-import msgspec.msgpack
 import zmq
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
-from vllm.utils.network_utils import make_zmq_socket, recv_router_dealer_message
-from vllm.v1.engine import FaultToleranceRequest, FaultToleranceResult
-from vllm.v1.serial_utils import run_method
 
 logger = init_logger(__name__)
 # Polling timeout in milliseconds for non-blocking message reception
@@ -35,8 +30,6 @@ class BaseSentinel:
     def __init__(
         self,
         vllm_config: VllmConfig,
-        upstream_cmd_addr: str | None,
-        downstream_cmd_addr: str | None,
         sentinel_identity: bytes | None,
         sentinel_tag: str | None,
     ):
@@ -45,22 +38,6 @@ class BaseSentinel:
         self.sentinel_tag = sentinel_tag
         self.logger = self._make_logger()
         self.ft_config = vllm_config.fault_tolerance_config
-        if upstream_cmd_addr is not None:
-            assert sentinel_identity is not None
-            self.upstream_cmd_socket = make_zmq_socket(
-                self.ctx,
-                upstream_cmd_addr,
-                zmq.DEALER,
-                bind=False,
-                identity=sentinel_identity,
-            )
-        if downstream_cmd_addr is not None:
-            self.downstream_cmd_socket = make_zmq_socket(
-                ctx=self.ctx,
-                path=downstream_cmd_addr,
-                socket_type=zmq.ROUTER,
-                bind=True,
-            )
 
     def _make_logger(self):
         def log(msg, *args, level="info", **kwargs):
@@ -91,252 +68,7 @@ class BaseSentinel:
         """
         raise NotImplementedError
 
-    def receive_upstream_cmd(self) -> tuple[bool, FaultToleranceRequest | None]:
-        """
-        This method polls the upstream command socket and attempts to receive
-        a fault tolerance request.
-        """
-        try:
-            has_msg, _, ft_request_bytes = recv_router_dealer_message(
-                self.upstream_cmd_socket,
-                use_poller=True,
-                poll_timeout=POLL_TIMEOUT_MS,
-                return_bytes=True,
-            )
-        except zmq.ZMQError:
-            self.logger(
-                "Socket closed, terminating %s", self.sentinel_name, level="info"
-            )
-            return False, None
-        if has_msg:
-            ft_request = msgspec.msgpack.decode(
-                ft_request_bytes, type=FaultToleranceRequest
-            )
-        else:
-            ft_request = None
-        return has_msg, ft_request
-
-    def receive_and_execute_upstream_cmd(self):
-        """
-        Receive and execute a command from upstream sentinel and send back
-        the execution result.
-        """
-        has_msg, ft_request = self.receive_upstream_cmd()
-        if has_msg:
-            assert ft_request is not None
-            ft_result = self._execute_cmd(ft_request)
-            self._send_execution_result(ft_result)
-
-    def _execute_cmd(self, ft_request: FaultToleranceRequest) -> FaultToleranceResult:
-        """
-        Execute a fault tolerance command on the current object.
-
-        Args:
-            ft_request (FaultToleranceRequest): The fault tolerance request containing
-                the instruction (method name), request_id (unique ID), and params
-                (method parameters).
-
-        Returns:
-            FaultToleranceResult: The result of the command execution containing:
-                - success (bool): True if the method ran without error; False otherwise.
-                - request_id (str): Unique ID of the command.
-                - reason (str | None): Error message if execution failed.
-        """
-        method, method_uuid, method_params = (
-            ft_request.instruction,
-            ft_request.request_id,
-            ft_request.params,
-        )
-        self.logger("Executing command: %s", ft_request, level="info")
-        try:
-            method_kwargs = method_params or {}
-            success: bool = run_method(self, method, args=(), kwargs=method_kwargs)
-            self.logger("Command (%s) succeeded: %s", method, success, level="info")
-            reason = None
-        except Exception as e:
-            self.logger(
-                "Error executing method %s: %s, %s",
-                method,
-                type(e).__name__,
-                e,
-                level="error",
-            )
-            success = False
-            reason = f"{type(e).__name__}: {e}"
-        return FaultToleranceResult(
-            success=success, request_id=method_uuid, reason=reason
-        )
-
-    @abstractmethod
-    def pause(self, timeout: int = 1, **kwargs) -> bool:
-        """
-        Pause the vLLM instance to enter fault-tolerance mode.
-        This method should be called when a fault is detected. It pauses the
-        execution, allowing the system to wait for fault-tolerance instructions
-        (e.g., retry, scale-down, or other control commands).
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def retry(self, timeout: int = 1, **kwargs) -> bool:
-        """
-        Retry execution after a transient recoverable fault.
-        """
-        raise NotImplementedError
-
-    def _send_execution_result(self, ft_result: FaultToleranceResult):
-        """
-        Send the result of executing a command back to the upstream.
-        """
-        assert hasattr(self, "upstream_cmd_socket"), "upstream_cmd_socket is required"
-        msg_bytes = msgspec.msgpack.encode(ft_result)
-        self.upstream_cmd_socket.send_multipart([b"", msg_bytes])
-
-    def _broadcast_command_to_downstream(
-        self,
-        method_name: str,
-        target_downstream_sentinels: set[bytes],
-        timeout: int = 5,
-        **kwargs,
-    ) -> tuple[bool, dict[bytes, FaultToleranceResult]]:
-        """
-        Broadcast a command to downstream sentinels and collect responses.
-        """
-        import uuid
-
-        from vllm.v1.engine import FaultToleranceRequest
-
-        # Create fault tolerance request
-        request_id = str(uuid.uuid4())
-        kwargs["timeout"] = timeout
-        ft_request = FaultToleranceRequest(
-            request_id=request_id,
-            instruction=method_name,
-            params=kwargs,
-        )
-
-        # Broadcast the instruction
-        msg_bytes = msgspec.msgpack.encode(ft_request)
-        for identity in target_downstream_sentinels:
-            self.downstream_cmd_socket.send_multipart([identity, b"", msg_bytes])
-
-        # Wait for responses
-        responses = self.wait_for_execution_result(
-            target_downstream_sentinels,
-            timeout,
-            ft_request,
-        )
-
-        # check the execution results
-        all_success = True
-        for sentinel_identity in target_downstream_sentinels:
-            response = responses.get(sentinel_identity)
-            if response is None:
-                self.logger(
-                    'Downstream sentinels timed out on "%s".',
-                    method_name,
-                    level="error",
-                )
-                all_success = False
-                break
-            elif not response.success:
-                self.logger(
-                    'Downstream sentinels failed to "%s" (reason: %s)',
-                    method_name,
-                    response.reason or "unknown",
-                    level="error",
-                )
-
-                all_success = False
-                break
-
-        return all_success, responses
-
-    def wait_for_execution_result(
-        self,
-        target_identities: set[bytes] | list[bytes],
-        timeout: int,
-        ft_request: "FaultToleranceRequest",
-    ) -> dict[bytes, "FaultToleranceResult"]:
-        """Wait for responses to a previously broadcast instruction and return
-        collected responses.
-
-        Args:
-            target_identities: Identities expected to respond (bytes).
-            timeout: Maximum wait time in seconds.
-            ft_request: FaultToleranceRequest object to match responses.
-
-        Returns:
-            Mapping from identity (bytes) to the parsed FaultToleranceResult.
-            Partial results are returned on timeout or error.
-        """
-        start = time.monotonic()
-        responses: dict[bytes, FaultToleranceResult] = {}
-
-        target_identities = set(target_identities)
-
-        while target_identities:
-            remaining = timeout - (time.monotonic() - start)
-            if remaining <= 0:
-                logger.debug(
-                    "Timeout while waiting for responses for instruction %s "
-                    "from identities: %s",
-                    ft_request.instruction,
-                    target_identities,
-                )
-                # Return partial results collected so far
-                return responses
-
-            try:
-                has_msg, identity, response_bytes = recv_router_dealer_message(
-                    self.downstream_cmd_socket,
-                    use_poller=True,
-                    poll_timeout=int(remaining * 1000),
-                    return_bytes=True,
-                )
-
-                # Skip if no message was received during this polling period
-                if not has_msg:
-                    continue
-
-                assert identity is not None
-                assert response_bytes is not None
-                ft_result = msgspec.msgpack.decode(
-                    response_bytes, type=FaultToleranceResult
-                )
-                recv_uuid = ft_result.request_id
-
-                # Ignore outdated or unrelated messages
-                if recv_uuid != ft_request.request_id:
-                    logger.debug(
-                        "Discarding outdated response: expected request_id=%s, got %s",
-                        ft_request.request_id,
-                        recv_uuid,
-                    )
-                    continue
-
-                # Record this endpoint's response
-                responses[identity] = ft_result
-                target_identities.discard(identity)
-
-            except Exception as e:
-                logger.error("Error while processing engine response: %s", e)
-                # Return partial results even on exception to avoid data loss
-                return responses
-
-        return responses
-
     def shutdown(self):
-        if (
-            hasattr(self, "upstream_cmd_socket")
-            and self.upstream_cmd_socket is not None
-        ):
-            self.upstream_cmd_socket.close()
-        if (
-            hasattr(self, "downstream_cmd_socket")
-            and self.downstream_cmd_socket is not None
-        ):
-            self.downstream_cmd_socket.close()
         if self.ctx is not None:
             self.ctx.term()
         self.sentinel_dead = True

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -6,7 +6,6 @@ import signal
 import threading
 import time
 import traceback
-import uuid
 from collections import defaultdict, deque
 from collections.abc import Callable, Generator
 from concurrent.futures import Future
@@ -49,7 +48,6 @@ from vllm.v1.engine import (
     EngineCoreOutputs,
     EngineCoreRequest,
     EngineCoreRequestType,
-    FaultToleranceRequest,
     FinishReason,
     PauseMode,
     ReconfigureDistributedRequest,
@@ -58,7 +56,7 @@ from vllm.v1.engine import (
     UtilityResult,
 )
 from vllm.v1.engine.base_sentinel import BaseSentinel
-from vllm.v1.engine.exceptions import EngineLoopPausedError, FaultInfo
+from vllm.v1.engine.exceptions import FaultInfo
 from vllm.v1.engine.utils import (
     EngineHandshakeMetadata,
     EngineZmqAddresses,
@@ -69,13 +67,9 @@ from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import SchedulerStats
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
-from vllm.v1.serial_utils import (
-    MsgpackDecoder,
-    MsgpackEncoder,
-    run_method,
-)
+from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.structured_output import StructuredOutputManager
-from vllm.v1.utils import compute_iteration_details, get_engine_client_zmq_addr
+from vllm.v1.utils import compute_iteration_details
 from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
@@ -97,28 +91,20 @@ class EngineCoreSentinel(BaseSentinel):
         self,
         engine_index: int,
         fault_signal_q: queue.Queue,
-        cmd_q: queue.Queue,
         busy_loop_active: threading.Event,
-        engine_input_q: queue.Queue,
-        client_cmd_addr: str,
-        worker_cmd_addr: str,
         engine_fault_socket_addr: str,
         sentinel_identity: bytes,
         vllm_config: VllmConfig,
     ):
         self.engine_index = engine_index
         super().__init__(
-            upstream_cmd_addr=client_cmd_addr,
-            downstream_cmd_addr=worker_cmd_addr,
             sentinel_identity=sentinel_identity,
             sentinel_tag=f"DP_{engine_index}",
             vllm_config=vllm_config,
         )
 
         self.fault_signal_q = fault_signal_q
-        self.cmd_q = cmd_q
         self.busy_loop_active = busy_loop_active
-        self.engine_input_q = engine_input_q
         parallel_config = vllm_config.parallel_config
         self.tp_size = parallel_config.tensor_parallel_size
         self.pp_size = parallel_config.pipeline_parallel_size
@@ -134,7 +120,6 @@ class EngineCoreSentinel(BaseSentinel):
         )
 
         self.poller = zmq.Poller()
-        self.communicator_aborted = False
         self.engine_running = True
         threading.Thread(
             target=self.run, daemon=True, name="EngineCoreSentinelMonitorThread"
@@ -150,25 +135,18 @@ class EngineCoreSentinel(BaseSentinel):
         while not self.sentinel_dead:
             # Check for engine fault signals
             self.poll_and_report_fault_events()
-            # Check for commands from ClientSentinel
-            self.receive_and_execute_upstream_cmd()
 
     def poll_and_report_fault_events(self):
         try:
-            engine_exception = self.fault_signal_q.get_nowait()
-            if isinstance(engine_exception, EngineLoopPausedError):
-                # The busy loop stopped due to another critical exception,
-                # put it back
-                self.logger("Engine paused", level="info")
-            else:
-                self.logger(
-                    "Detected exception %s: %s\n Call Stack:\n%s",
-                    type(engine_exception).__name__,
-                    engine_exception,
-                    "".join(traceback.format_tb(engine_exception.__traceback__)),
-                    level="error",
-                )
-                self._report_exception_to_client_sentinel(engine_exception)
+            engine_exception = self.fault_signal_q.get()
+            self.logger(
+                "Detected exception %s: %s\n Call Stack:\n%s",
+                type(engine_exception).__name__,
+                engine_exception,
+                "".join(traceback.format_tb(engine_exception.__traceback__)),
+                level="error",
+            )
+            self._report_exception_to_client_sentinel(engine_exception)
             self.engine_running = False
         except queue.Empty:
             pass
@@ -177,98 +155,6 @@ class EngineCoreSentinel(BaseSentinel):
         msg = FaultInfo.from_exception(exception, self.engine_index).serialize()
         msg_bytes = msg.encode("utf-8")
         self.engine_fault_socket.send_multipart([b"", msg_bytes])
-
-    def pause(self, timeout: int = 1, **kwargs) -> bool:
-        """
-        Pause the busy loop safely.
-        Args:
-            timeout:wait for the busy loop to acknowledge the pause signal
-        """
-        self.logger("Start pausing EngineCore", level="info")
-        soft_pause = kwargs.get("soft_pause", False)
-        start_time = time.monotonic()
-        if self.engine_running:
-            # Clear the flag to signal busy loop should pause
-            self.busy_loop_active.clear()
-            # Put a sentinel (empty request) to unblock the busy loop
-            # if it's blocked on input_queue.get()
-            self.engine_input_q.put((EngineCoreRequestType.PAUSE, None))
-            success, _ = self._broadcast_command_to_downstream(
-                "pause",
-                self._get_target_worker_identity(),
-                timeout=timeout,
-                soft_pause=soft_pause,
-            )
-            elapsed = time.monotonic() - start_time
-            if success:
-                remaining_timeout = max(0, timeout - elapsed)
-                try:
-                    # Wait for engine to acknowledge the pause via fault_signal_q
-                    exception = self.fault_signal_q.get(timeout=remaining_timeout)
-                    self.fault_signal_q.put(exception)
-                    success = True
-                    self.engine_running = False
-                except queue.Empty:
-                    # Timeout waiting for pause acknowledgment
-                    success = False
-        else:
-            # already paused
-            success = True
-            if not soft_pause:
-                # abort the communicators
-                success, _ = self._broadcast_command_to_downstream(
-                    "pause",
-                    self._get_target_worker_identity(),
-                    timeout=timeout,
-                    soft_pause=False,
-                )
-        return success
-
-    def retry(self, timeout: int = 1, **kwargs) -> bool:
-        """
-        Handle the retry instruction from the ClientSentinel.
-        This instruction tells the EngineCore to continue its busy loop
-        after being suspended due to an exception.
-        """
-        if self.engine_running:
-            return True
-        new_stateless_dp_group_port = kwargs.get("new_stateless_dp_group_port")
-        start_time = time.monotonic()
-        identities = self._get_target_worker_identity()
-        success, _ = self._broadcast_command_to_downstream(
-            "retry", identities, timeout=timeout
-        )
-        if not success:
-            return success
-
-        if self.dp_size > 1:
-            # If the Gloo communication times out
-            # the data parallel group (dp_group) needs to be reinitialized
-            command = "reinit_dp_group_on_fault_tolerance"
-            reinit_request = FaultToleranceRequest(
-                instruction=command,
-                request_id=str(uuid.uuid4()),
-                params={"new_stateless_dp_group_port": new_stateless_dp_group_port},
-            )
-            self.cmd_q.put(reinit_request)
-        else:
-            self.cmd_q.put(None)
-
-        # Ensure busy loop has been recovered.
-        elapsed = time.monotonic() - start_time
-        remaining_timeout = max(0, timeout - elapsed)
-        success = self.busy_loop_active.wait(timeout=remaining_timeout)
-        self.engine_running = success
-        assert self.cmd_q.empty(), "cmd_q must be empty after execution"
-        return success
-
-    def _get_target_worker_identity(self):
-        identities = set()
-        for tp_rank in range(self.tp_size):
-            for pp_rank in range(self.pp_size):
-                identity = f"PP{pp_rank}_TP{tp_rank}".encode()
-                identities.add(identity)
-        return identities
 
     def shutdown(self):
         if self.engine_fault_socket is not None:
@@ -295,47 +181,11 @@ def busy_loop_wrapper(busy_loop_func):
                     self.fault_signal_q.put(original_exc)
                     logger.warning(
                         "[BusyLoopWrapper] EngineCore busy loop raised an exception. "
-                        "Suspended and waiting for fault tolerance "
-                        "instructions."
                     )
-
-                    # Put running requests into waiting list.
-                    timestamp = time.monotonic()
-                    while self.scheduler.running:
-                        request = self.scheduler.running.pop()
-                        self.scheduler.preempt_request(request, timestamp)
-                    self.scheduler.prev_step_scheduled_req_ids.clear()
-                    if self.batch_queue is not None:
-                        self.batch_queue.clear()
-
-                    try:
-                        # Block until recovery command received
-                        ft_request = self.cmd_q.get(
-                            timeout=self.engine_recovery_timeout
-                        )
-
-                        if ft_request is not None:
-                            logger.debug(
-                                "[BusyLoopWrapper] Received fault tolerance "
-                                "command: %s",
-                                ft_request.instruction,
-                            )
-                            method, params = (ft_request.instruction, ft_request.params)
-                            run_method(self, method, args=(), kwargs=params)
-                        # recovery succeeded; restart the busy loop
-                        continue
-                    except queue.Empty:
-                        # No handling instruction received within predefined
-                        # timeout period.
-                        logger.error(
-                            "[BusyLoopWrapper] Fault tolerance instruction not received"
-                            " within timeout. Proceeding with default exception "
-                            "handling."
-                        )
-                    except Exception as cmd_exc:
-                        raise RuntimeError(
-                            "Fault tolerance execution failed."
-                        ) from cmd_exc
+                    # todo: Currently only wait a certain time before shutting
+                    #  down the engine. Will implement fault tolerance methods
+                    #  in the upcoming PRs.
+                    time.sleep(self.engine_recovery_timeout)
 
                 # Fault tolerance not enabled OR no instruction received
                 # before timeout. Re-raise the original exception
@@ -1031,29 +881,18 @@ class EngineCoreProc(EngineCore):
                 # Track whether the busy loop is currently active.
                 self.busy_loop_active = threading.Event()
                 self.fault_signal_q: queue.Queue[Exception] = queue.Queue()
-                self.cmd_q: queue.Queue[FaultToleranceRequest | None] = queue.Queue(
-                    maxsize=1
-                )
                 self.engine_recovery_timeout = ft_config.engine_recovery_timeout
                 engine_core_sentinel_ids = addresses.engine_core_sentinel_identities
                 assert engine_core_sentinel_ids is not None
                 assert addresses.engine_fault_socket_addr is not None
-                assert addresses.engine_core_sentinel_cmd_addr is not None
-                # The ZMQ address between engine_core_sentinel and worker_sentinel.
-                worker_cmd_addr = get_engine_client_zmq_addr(True, "0.0.0.0")
                 self.engine_core_sentinel = EngineCoreSentinel(
                     engine_index=self.engine_index,
                     fault_signal_q=self.fault_signal_q,
-                    cmd_q=self.cmd_q,
                     busy_loop_active=self.busy_loop_active,
-                    engine_input_q=self.input_queue,
                     engine_fault_socket_addr=addresses.engine_fault_socket_addr,
-                    client_cmd_addr=addresses.engine_core_sentinel_cmd_addr,
-                    worker_cmd_addr=worker_cmd_addr,
                     sentinel_identity=engine_core_sentinel_ids[self.engine_index],
                     vllm_config=vllm_config,
                 )
-                vllm_config.fault_tolerance_config.worker_cmd_addr = worker_cmd_addr
                 # Do not shut down the engine immediately upon failure.
                 executor_fail_callback = lambda: self.fault_signal_q.put(
                     RuntimeError(f"Executor on EngineCore {self.engine_index} failed.")
@@ -1348,17 +1187,11 @@ class EngineCoreProc(EngineCore):
         # Loop until process is sent a SIGINT or SIGTERM
         while True:
             # 1) Poll the input queue until there is work to do.
-            self._check_busy_loop_active()
             self._process_input_queue()
             # 2) Step the engine core and return the outputs.
-            self._check_busy_loop_active()
             self._process_engine_step()
             # 3) Run any per-step hooks.
             self._process_per_step_hooks()
-
-    def _check_busy_loop_active(self):
-        if self.enable_fault_tolerance and not self.busy_loop_active.is_set():
-            raise EngineLoopPausedError("Engine busy loop is paused.")
 
     def _process_input_queue(self):
         """Exits when an engine step needs to be performed."""
@@ -1425,8 +1258,6 @@ class EngineCoreProc(EngineCore):
             self.add_request(req, request_wave)
         elif request_type == EngineCoreRequestType.ABORT:
             self.abort_requests(request)
-        elif request_type == EngineCoreRequestType.PAUSE:
-            self._check_busy_loop_active()
         elif request_type == EngineCoreRequestType.UTILITY:
             client_idx, call_id, method_name, args = request
             output = UtilityOutput(call_id)
@@ -1790,9 +1621,7 @@ class DPEngineCoreProc(EngineCoreProc):
         assert 0 <= local_dp_rank <= dp_rank < dp_size
 
         self.dp_rank = dp_rank
-        self.dp_group = vllm_config.parallel_config.stateless_init_dp_group(
-            fault_tolerance_config=vllm_config.fault_tolerance_config
-        )
+        self.dp_group = vllm_config.parallel_config.stateless_init_dp_group()
 
     def shutdown(self):
         super().shutdown()
@@ -1847,11 +1676,9 @@ class DPEngineCoreProc(EngineCoreProc):
         # Loop until process is sent a SIGINT or SIGTERM
         while True:
             # 1) Poll the input queue until there is work to do.
-            self._check_busy_loop_active()
             self._process_input_queue()
 
             # 2) Step the engine core.
-            self._check_busy_loop_active()
             executed = self._process_engine_step()
             self._maybe_publish_request_counts()
             local_unfinished_reqs = self.scheduler.has_unfinished_requests()
@@ -1863,11 +1690,9 @@ class DPEngineCoreProc(EngineCoreProc):
 
                 # We are in a running state and so must execute a dummy pass
                 # if the model didn't execute any ready requests.
-                self._check_busy_loop_active()
                 self.execute_dummy_batch()
 
             # 3) All-reduce operation to determine global unfinished reqs.
-            self._check_busy_loop_active()
             self.engines_running = self._has_global_unfinished_reqs(
                 local_unfinished_reqs
             )
@@ -1899,14 +1724,6 @@ class DPEngineCoreProc(EngineCoreProc):
             return True
 
         return ParallelConfig.has_unfinished_dp(self.dp_group, local_unfinished)
-
-    def reinit_dp_group_on_fault_tolerance(self, new_stateless_dp_group_port: int):
-        stateless_destroy_torch_distributed_process_group(self.dp_group)
-        self.dp_group = self.vllm_config.parallel_config.stateless_init_dp_group(
-            fault_tolerance_config=self.vllm_config.fault_tolerance_config,
-            dp_init_port=new_stateless_dp_group_port,
-        )
-        self.step_counter = 0
 
     def reinitialize_distributed(
         self, reconfig_request: ReconfigureDistributedRequest

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -6,7 +6,6 @@ import json
 import queue
 import sys
 import threading
-import time
 import uuid
 import weakref
 from abc import ABC, abstractmethod
@@ -34,15 +33,12 @@ from vllm.utils.network_utils import (
     get_open_port,
     get_open_zmq_inproc_path,
     make_zmq_socket,
-    recv_router_dealer_message,
 )
 from vllm.v1.engine import (
     EngineCoreOutputs,
     EngineCoreRequest,
     EngineCoreRequestType,
     EngineStatusType,
-    FaultToleranceRequest,
-    FaultToleranceResult,
     PauseMode,
     ReconfigureDistributedRequest,
     ReconfigureRankType,
@@ -64,7 +60,6 @@ from vllm.v1.serial_utils import (
     MsgpackEncoder,
     bytestr,
 )
-from vllm.v1.utils import get_engine_client_zmq_addr
 
 logger = init_logger(__name__)
 
@@ -279,11 +274,6 @@ class EngineCoreClient(ABC):
     ) -> list[_R]:
         raise NotImplementedError
 
-    async def handle_fault(
-        self, fault_tolerance_request: FaultToleranceRequest
-    ) -> FaultToleranceResult:
-        raise NotImplementedError
-
     async def fault_reporter(self):
         raise NotImplementedError
 
@@ -383,8 +373,6 @@ class ClientSentinel(BaseSentinel):
         self,
         vllm_config: VllmConfig,
         engine_fault_socket_addr: str,
-        client_sentinel_cmd_addr: str,
-        engine_core_sentinel_cmd_addr: str,
         engine_core_sentinel_identities: dict[int, bytes],
         fault_state_pub_socket_addr: str,
     ):
@@ -396,21 +384,11 @@ class ClientSentinel(BaseSentinel):
         num_dp_managed = (
             dp_local_size if vllm_config.parallel_config.local_engines_only else dp_size
         )
-        host = vllm_config.parallel_config.data_parallel_master_ip
 
         super().__init__(
-            upstream_cmd_addr=None,
-            downstream_cmd_addr=engine_core_sentinel_cmd_addr,
             sentinel_identity=None,
             sentinel_tag=None,
             vllm_config=vllm_config,
-        )
-
-        self.fault_tolerance_req_socket = make_zmq_socket(
-            ctx=self.ctx,
-            path=client_sentinel_cmd_addr,
-            socket_type=zmq.ROUTER,
-            bind=True,
         )
 
         self.fault_receiver_socket = make_zmq_socket(
@@ -426,24 +404,6 @@ class ClientSentinel(BaseSentinel):
             socket_type=zmq.PUB,
             bind=True,
         )
-        # Queue to serialize fault tolerance instruction execution:
-        # (client_identity, FaultToleranceRequest)
-        self.ft_request_queue: queue.Queue[
-            tuple[bytes | None, FaultToleranceRequest]
-        ] = queue.Queue(
-            maxsize=2
-        )  # allow one pause command and another fault tolerance command
-        self.ft_result_queue: queue.Queue[tuple[bytes | None, FaultToleranceResult]] = (
-            queue.Queue(maxsize=2)
-        )
-        self.inproc_comm_addr = get_engine_client_zmq_addr(local_only=True, host=host)
-        self.inproc_res_recv_socket = make_zmq_socket(
-            ctx=self.ctx, path=self.inproc_comm_addr, socket_type=zmq.PAIR, bind=True
-        )
-        self.inproc_res_send_socket = make_zmq_socket(
-            ctx=self.ctx, path=self.inproc_comm_addr, socket_type=zmq.PAIR, bind=False
-        )
-
         self.is_faulted = threading.Event()
         self.engine_status_dict: ThreadSafeDict[int, dict[str, EngineStatusType]] = (
             ThreadSafeDict()
@@ -462,92 +422,6 @@ class ClientSentinel(BaseSentinel):
             target=self.run, daemon=True, name="ClientSentinelCmdAndFaultReceiverThread"
         ).start()
 
-        threading.Thread(
-            target=self._process_ft_requests_loop,
-            daemon=True,
-            name="ClientSentinelFtRequestsLoopThread",
-        ).start()
-
-    def _process_ft_requests_loop(self) -> None:
-        """
-        Worker loop to process Fault Tolerance (FT) requests
-        """
-        try:
-            while not self.sentinel_dead:
-                try:
-                    identity, ft_request = self.ft_request_queue.get(timeout=1)
-                    ft_result = self._execute_cmd(ft_request)
-                    self.ft_result_queue.put((identity, ft_result))
-                    self.inproc_res_send_socket.send(msgspec.msgpack.encode(ft_result))
-                except queue.Empty:
-                    pass
-        except zmq.ZMQError:
-            # Socket is closed.
-            pass
-
-    def retry(self, timeout: int = 1, **kwargs) -> bool:
-        for engine_status in self.engine_status_dict.values():
-            if engine_status["status"] == EngineStatusType.DEAD:
-                self.logger(
-                    "Engine core is dead; retry won't work.",
-                    level="warning",
-                )
-                return False
-
-        target_engines = set(self.engine_core_sentinel_identities.values())
-        new_stateless_dp_group_port = get_open_port()
-        success, _ = self._broadcast_command_to_downstream(
-            "retry",
-            target_engines,
-            new_stateless_dp_group_port=new_stateless_dp_group_port,
-            timeout=timeout,
-        )
-
-        for engine_index, _ in self.engine_status_dict.items():
-            self.engine_status_dict[engine_index] = {"status": EngineStatusType.HEALTHY}
-
-        if success:
-            self.is_faulted.clear()
-            self._pub_engine_status()
-        return success
-
-    def pause(self, timeout: int = 1, **kwargs) -> bool:
-        """Pause engine cores, return True if successful. Best-effort operation."""
-        self.logger(
-            "Pause operation is best-effort only. Due to the complexity of "
-            "collective communications (e.g., timing dependencies and "
-            "synchronization barriers), pausing may not always succeed. If "
-            "the process remains unresponsive or collective operations "
-            "cannot be interrupted, consider shutting down and restarting "
-            "the instance.",
-            level="warning",
-        )
-        exclude_engine_index = kwargs.get("exclude_engine_index")
-        soft_pause = kwargs.get("soft_pause", False)
-        alive_engines = {
-            identity
-            for index, identity in self.engine_core_sentinel_identities.items()
-            if self.engine_status_dict[index]["status"] != EngineStatusType.DEAD
-            and (exclude_engine_index is None or index not in exclude_engine_index)
-        }
-        success, responses = self._broadcast_command_to_downstream(
-            "pause",
-            alive_engines,
-            timeout=timeout,
-            soft_pause=soft_pause,
-        )
-        identity_to_index = {
-            identity: index
-            for index, identity in self.engine_core_sentinel_identities.items()
-        }
-        for engine_identity, ft_result in responses.items():
-            if ft_result.success:
-                i = identity_to_index[engine_identity]
-                engine_status = self.engine_status_dict[i]["status"]
-                if engine_status == EngineStatusType.HEALTHY:
-                    self.engine_status_dict[i] = {"status": EngineStatusType.PAUSED}
-        return success
-
     def _pub_engine_status(self):
         engine_status = self.engine_status_dict.to_dict()
         self.fault_state_pub_socket.send_multipart(
@@ -555,7 +429,7 @@ class ClientSentinel(BaseSentinel):
         )
 
     def _alert_and_pause(self):
-        """Receive fault info from engine and pause engines if first fault."""
+        """Receive fault info from engine."""
         try:
             identity, _, message = self.fault_receiver_socket.recv_multipart()
             fault_info = FaultInfo.from_json(message.decode("utf-8"))
@@ -570,42 +444,16 @@ class ClientSentinel(BaseSentinel):
             self._pub_engine_status()
             if not self.is_faulted.is_set():
                 self.is_faulted.set()
-                pause_request = FaultToleranceRequest(
-                    request_id=str(uuid.uuid4()),
-                    instruction="pause",
-                    params={
-                        "timeout": self.ft_config.gloo_comm_timeout,
-                        "soft_pause": False,
-                    },
-                )
-                while not self._dispatch_fault_tolerance_request(pause_request, None):
-                    # If the queue is full, it means another fault tolerance
-                    # command is being executed.
-                    # Wait and retry until we can add the pause command to
-                    # the queue.
-                    time.sleep(0.1)
 
         except zmq.ZMQError:
             # Socket was closed during polling, exit loop.
             self.logger("Fault receiver socket closed, stopping thread.", level="info")
             raise
 
-    def _dispatch_fault_tolerance_request(
-        self, ft_request: FaultToleranceRequest, identity: bytes | None
-    ) -> bool:
-        """Add fault tolerance request to queue, return False if busy."""
-        try:
-            self.ft_request_queue.put_nowait((identity, ft_request))
-        except queue.Full:
-            return False
-        return True
-
     def run(self):
         """Poll for fault messages and commands, dispatch to handlers."""
         poller = zmq.Poller()
         poller.register(self.fault_receiver_socket, zmq.POLLIN)
-        poller.register(self.fault_tolerance_req_socket, zmq.POLLIN)
-        poller.register(self.inproc_res_recv_socket, zmq.POLLIN)
         try:
             while not self.sentinel_dead:
                 events = poller.poll(timeout=5000)
@@ -615,40 +463,7 @@ class ClientSentinel(BaseSentinel):
                 if self.fault_receiver_socket in events:
                     # If a fault message is received, alert and attempt to pause.
                     self._alert_and_pause()
-                if self.fault_tolerance_req_socket in events:
-                    # Received fault tolerance command from client.
-                    # Add corresponding command to the queue.
-                    parts = self.fault_tolerance_req_socket.recv_multipart()
-                    identity = parts[0]
-                    msg_bytes = parts[-1]
-                    ft_request = msgspec.msgpack.decode(
-                        msg_bytes, type=FaultToleranceRequest
-                    )
-                    success = self._dispatch_fault_tolerance_request(
-                        ft_request, identity
-                    )
-                    if not success:
-                        # If we're busy, reply with a busy message.
-                        msg = (
-                            "System busy, vLLM is executing another fault "
-                            "tolerance instruction."
-                        )
-                        res = FaultToleranceResult(ft_request.request_id, False, msg)
-                        resp = msgspec.msgpack.encode(res)
-                        self.fault_tolerance_req_socket.send_multipart(
-                            [identity, b"", resp]
-                        )
-                if self.inproc_res_recv_socket in events:
-                    # Send FT execution result back to client.
-                    msg = self.inproc_res_recv_socket.recv()
-                    recv_res = msgspec.msgpack.decode(msg, type=FaultToleranceResult)
-                    identity, ft_result = self.ft_result_queue.get_nowait()
-                    assert recv_res.request_id == ft_result.request_id
-                    if identity is not None:
-                        self.fault_tolerance_req_socket.send_multipart(
-                            [identity, b"", msg]
-                        )
-                    self._pub_engine_status()
+
         except zmq.ZMQError:
             # Context terminated, exit thread cleanly.
             pass
@@ -656,9 +471,6 @@ class ClientSentinel(BaseSentinel):
     def shutdown(self):
         self.fault_receiver_socket.close()
         self.fault_state_pub_socket.close()
-        self.inproc_res_send_socket.close()
-        self.inproc_res_recv_socket.close()
-        self.fault_tolerance_req_socket.close()
         super().shutdown()
 
 
@@ -681,7 +493,6 @@ class BackgroundResources:
     stats_update_task: asyncio.Task | None = None
     shutdown_path: str | None = None
     client_sentinel: ClientSentinel | None = None
-    client_sentinel_cmd_socket: zmq.Socket | None = None
     fault_state_sub_socket: zmq.Socket | None = None
 
     # Set if any of the engines are dead. Here so that the output
@@ -709,7 +520,6 @@ class BackgroundResources:
                 self.first_req_send_socket,
                 self.first_req_rcv_socket,
                 self.stats_update_socket,
-                self.client_sentinel_cmd_socket,
                 self.fault_state_sub_socket,
             )
 
@@ -791,15 +601,12 @@ class MPClient(EngineCoreClient):
         self.resources = BackgroundResources(ctx=sync_ctx)
         self._finalizer = weakref.finalize(self, self.resources)
         success = False
-
         try:
             # State used for data parallel.
             self.engines_running = False
 
             self.stats_update_address: str | None = None
             self.engine_fault_socket_addr: str | None = None
-            self.client_sentinel_cmd_addr: str | None = None
-            self.engine_core_sentinel_cmd_addr: str | None = None
             self.engine_core_sentinel_identities: dict[int, bytes] | None = None
             self.fault_state_pub_socket_addr: str | None = None
             if client_addresses:
@@ -810,12 +617,6 @@ class MPClient(EngineCoreClient):
                 if vllm_config.fault_tolerance_config.enable_fault_tolerance:
                     self.engine_fault_socket_addr = client_addresses[
                         "engine_fault_socket_addr"
-                    ]
-                    self.client_sentinel_cmd_addr = client_addresses[
-                        "client_sentinel_cmd_addr"
-                    ]
-                    self.engine_core_sentinel_cmd_addr = client_addresses[
-                        "engine_core_sentinel_cmd_addr"
                     ]
                     self.engine_core_sentinel_identities = {
                         int(k): v.encode("utf-8")
@@ -841,10 +642,6 @@ class MPClient(EngineCoreClient):
                 self.stats_update_address = addresses.frontend_stats_publish_address
                 if vllm_config.fault_tolerance_config.enable_fault_tolerance:
                     self.engine_fault_socket_addr = addresses.engine_fault_socket_addr
-                    self.client_sentinel_cmd_addr = addresses.client_sentinel_cmd_addr
-                    self.engine_core_sentinel_cmd_addr = (
-                        addresses.engine_core_sentinel_cmd_addr
-                    )
                     self.engine_core_sentinel_identities = (
                         addresses.engine_core_sentinel_identities
                     )
@@ -976,8 +773,6 @@ class MPClient(EngineCoreClient):
             daemon=True,
             name="ClientEngineMonitor",
         ).start()
-
-        return
 
 
 def _process_utility_output(
@@ -1204,21 +999,16 @@ class AsyncMPClient(MPClient):
         if vllm_config.fault_tolerance_config.enable_fault_tolerance:
             self.is_faulted = threading.Event()
             assert self.engine_fault_socket_addr is not None
-            assert self.client_sentinel_cmd_addr is not None
-            assert self.engine_core_sentinel_cmd_addr is not None
             assert self.engine_core_sentinel_identities is not None
             assert self.fault_state_pub_socket_addr is not None
             if self.client_index == 0:
                 self.client_sentinel = ClientSentinel(
                     vllm_config,
                     self.engine_fault_socket_addr,
-                    self.client_sentinel_cmd_addr,
-                    self.engine_core_sentinel_cmd_addr,
                     self.engine_core_sentinel_identities,
                     self.fault_state_pub_socket_addr,
                 )
                 self.resources.client_sentinel = self.client_sentinel
-            self.ft_request_lock = threading.Lock()
             self.engine_status_dict: ThreadSafeDict[
                 int, dict[str, EngineStatusType]
             ] = ThreadSafeDict()
@@ -1230,18 +1020,10 @@ class AsyncMPClient(MPClient):
             )
             self.sync_ctx = self.resources.ctx
 
-            self.client_sentinel_cmd_socket = make_zmq_socket(
-                self.sync_ctx,
-                self.client_sentinel_cmd_addr,
-                zmq.DEALER,
-                bind=False,
-                identity=self.identity,
-            )
             self.fault_state_sub_socket = make_zmq_socket(
                 self.sync_ctx, self.fault_state_pub_socket_addr, zmq.SUB, bind=False
             )
             self.fault_state_sub_socket.setsockopt(zmq.SUBSCRIBE, b"vllm_fault")
-            self.resources.client_sentinel_cmd_socket = self.client_sentinel_cmd_socket
             self.resources.fault_state_sub_socket = self.fault_state_sub_socket
             threading.Thread(
                 target=self._engine_status_listener,
@@ -1450,63 +1232,6 @@ class AsyncMPClient(MPClient):
         return await self.call_utility_async(
             "collective_rpc", method, timeout, args, kwargs
         )
-
-    async def handle_fault(
-        self, ft_request: FaultToleranceRequest
-    ) -> FaultToleranceResult:
-        if getattr(self.resources, "engine_dead", False):
-            return FaultToleranceResult(
-                request_id=ft_request.request_id, success=False, reason="engine is dead"
-            )
-
-        def _send_and_recv():
-            with self.ft_request_lock:
-                # send the FaultToleranceRequest to ClientSentinel and recv
-                # corresponding result.We may have concurrent handle_fault calls.
-                # But we need to keep them sequential to avoid interleaving
-                # their messages. The ft_request_lock ensures that only one
-                # handle_fault call can send/recv on the socket at a time, so
-                # that each request gets the correct corresponding result.
-                payload = msgspec.msgpack.encode(ft_request)
-                sock = self.client_sentinel_cmd_socket
-                sock.send_multipart([b"", payload])
-
-                # Determine timeout if provided (add 1 second buffer).
-                timeout_secs = ft_request.params.get("timeout")
-                assert timeout_secs is not None
-                timeout_secs = 1 + timeout_secs
-                end_time = time.monotonic() + timeout_secs
-
-                while True:
-                    remaining = end_time - time.monotonic()
-                    if remaining <= 0:
-                        # Timed out waiting for matching reply.
-                        return FaultToleranceResult(
-                            request_id=ft_request.request_id,
-                            success=False,
-                            reason="timeout waiting for fault tolerance result",
-                        )
-                    poll_timeout_ms = max(1, int(remaining * 1000))
-                    has_msg, _, msg_bytes = recv_router_dealer_message(
-                        socket=sock,
-                        use_poller=True,
-                        poll_timeout=poll_timeout_ms,
-                        return_bytes=True,
-                    )
-                    if has_msg:
-                        res = msgspec.msgpack.decode(
-                            msg_bytes, type=FaultToleranceResult
-                        )
-
-                        if res.request_id == ft_request.request_id:
-                            return res
-                    # Non-matching request_id, continue waiting.
-                    continue
-
-        # Perform blocking ZMQ send/recv in a worker thread to avoid
-        # blocking the asyncio event loop.
-        ft_result = await asyncio.to_thread(_send_and_recv)
-        return ft_result
 
     def _engine_status_listener(self):
         while True:

--- a/vllm/v1/engine/exceptions.py
+++ b/vllm/v1/engine/exceptions.py
@@ -23,15 +23,6 @@ class EngineDeadError(Exception):
         self.__suppress_context__ = suppress_context
 
 
-class EngineLoopPausedError(Exception):
-    """
-    Raised when the EngineCore loop is temporarily paused on purpose,
-    e.g., to handle fault-tolerance.
-    """
-
-    pass
-
-
 @dataclass
 class FaultInfo:
     type: str

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 import contextlib
 import multiprocessing
 import os
@@ -63,7 +64,6 @@ class EngineZmqAddresses:
     inputs: list[str]
     # ZMQ output socket addresses for each front-end client (responses)
     outputs: list[str]
-
     # ZMQ input socket address of DP coordinator if applicable
     coordinator_input: str | None = None
     # ZMQ output socket address of DP coordinator if applicable
@@ -74,10 +74,6 @@ class EngineZmqAddresses:
     frontend_stats_publish_address: str | None = None
     # ZMQ fault_state_pub_socket address of client sentinel
     fault_state_pub_socket_addr: str | None = None
-    # ZMQ client_sentinel_cmd socket address of client sentinel
-    client_sentinel_cmd_addr: str | None = None
-    # ZMQ engine_core_sentinel_cmd socket address of engine_core sentinel
-    engine_core_sentinel_cmd_addr: str | None = None
     # ZMQ engine_fault socket address of EngineCoreSentinel
     engine_fault_socket_addr: str | None = None
     # Identities of engine core DEALER sockets, keyed by engine index.
@@ -243,6 +239,7 @@ class CoreEngineProcManager:
                 sentinels.remove(sentinel)
 
     def join_first(self):
+        """Wait for any process to exit."""
         connection.wait(proc.sentinel for proc in self.processes)
 
     def sentinels(self) -> list:
@@ -446,7 +443,6 @@ class CoreEngineActorManager:
                     local_dp_rank=local_index,
                 )
             )
-
             if local_client:
                 self.local_engine_actors.append(actor)
             else:
@@ -966,12 +962,6 @@ def launch_core_engines(
             local_only=False,
             host=vllm_config.parallel_config.data_parallel_master_ip,
             port=vllm_config.fault_tolerance_config.internal_fault_report_port,
-        )
-        addresses.client_sentinel_cmd_addr = get_engine_client_zmq_addr(
-            local_only=True, host=host
-        )
-        addresses.engine_core_sentinel_cmd_addr = get_engine_client_zmq_addr(
-            local_only=local_engines_only, host=host
         )
         identity_group = generate_identity_group(
             peer1="client",

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -176,8 +176,6 @@ class APIServerProcessManager:
         output_addresses: list[str],
         stats_update_address: str | None = None,
         engine_fault_socket_addr: str | None = None,
-        client_sentinel_cmd_addr: str | None = None,
-        engine_core_sentinel_cmd_addr: str | None = None,
         engine_core_sentinel_identities: dict[int, bytes] | None = None,
         fault_state_pub_socket_addr: str | None = None,
     ):
@@ -213,15 +211,9 @@ class APIServerProcessManager:
             if stats_update_address is not None:
                 client_config["stats_update_address"] = stats_update_address
             if engine_fault_socket_addr is not None:
-                assert client_sentinel_cmd_addr is not None
-                assert engine_core_sentinel_cmd_addr is not None
                 assert engine_core_sentinel_identities is not None
                 assert fault_state_pub_socket_addr is not None
                 client_config["engine_fault_socket_addr"] = engine_fault_socket_addr
-                client_config["client_sentinel_cmd_addr"] = client_sentinel_cmd_addr
-                client_config["engine_core_sentinel_cmd_addr"] = (
-                    engine_core_sentinel_cmd_addr
-                )
                 client_config["engine_core_sentinel_identities"] = json.dumps(
                     {
                         k: v.decode("utf-8")

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -121,7 +121,6 @@ from vllm.v1.attention.backends.utils import (
 )
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
-from vllm.v1.engine.exceptions import EngineLoopPausedError
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     ChunkedLocalAttentionSpec,
@@ -714,12 +713,6 @@ class GPUModelRunner(
         self.kv_connector_output: KVConnectorOutput | None = None
         self.mamba_state_idx: dict[str, int] = {}
         self.layerwise_nvtx_hooks_registered = False
-
-        self.pause_event = threading.Event()
-
-    def _check_pause_event(self):
-        if self.pause_event.is_set():
-            raise EngineLoopPausedError("Worker is paused.")
 
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
@@ -3055,7 +3048,6 @@ class GPUModelRunner(
         Returns:
             Model output tensor
         """
-        self._check_pause_event()
         return self.model(
             input_ids=input_ids,
             positions=positions,
@@ -4876,7 +4868,6 @@ class GPUModelRunner(
                     slot_mapping=slot_mappings,
                 ),
             ):
-                self._check_pause_event()
                 outputs = self.model(
                     input_ids=input_ids,
                     positions=positions,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -5,10 +5,9 @@
 import gc
 import os
 import threading
+import time
 from collections.abc import Callable
-from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
 from contextlib import AbstractContextManager, nullcontext
-from functools import partial
 from types import NoneType
 from typing import TYPE_CHECKING, Any, cast
 
@@ -21,12 +20,10 @@ import vllm.envs as envs
 from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.config.compilation import CompilationMode
 from vllm.distributed import (
-    cleanup_dist_env_and_memory,
     ensure_model_parallel_initialized,
     init_distributed_environment,
     set_custom_all_reduce,
 )
-from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
 from vllm.distributed.ec_transfer import ensure_ec_transfer_initialized
 from vllm.distributed.eplb.eplb_utils import override_envs_for_eplb
 from vllm.distributed.kv_transfer import (
@@ -36,9 +33,7 @@ from vllm.distributed.kv_transfer import (
     has_kv_transfer_group,
 )
 from vllm.distributed.parallel_state import (
-    GroupCoordinator,
     Handle,
-    get_all_model_groups,
     get_pcp_group,
     get_pp_group,
     get_tp_group,
@@ -114,9 +109,6 @@ class WorkerSentinel(BaseSentinel):
     def __init__(
         self,
         vllm_config: VllmConfig,
-        pause_event: threading.Event,
-        init_distributed_env_callback: Callable,
-        clear_input_batch_callback: Callable,
         device: torch.cuda.device,
     ):
         self.dp_rank = vllm_config.parallel_config.data_parallel_rank
@@ -124,113 +116,36 @@ class WorkerSentinel(BaseSentinel):
         self.pp_rank = get_pp_group().rank_in_group
         identity = f"PP{self.pp_rank}_TP{self.tp_rank}"
         super().__init__(
-            upstream_cmd_addr=vllm_config.fault_tolerance_config.worker_cmd_addr,
-            downstream_cmd_addr=None,
             sentinel_identity=identity.encode(),
             sentinel_tag=f"{self.dp_rank}_{identity}",
             vllm_config=vllm_config,
         )
         self.vllm_config = vllm_config
-        self.init_distributed_env_callback = init_distributed_env_callback
-        self.clear_input_batch_callback = clear_input_batch_callback
         self.device = device
 
-        self.pause_event = pause_event
-        self.communicator_aborted = False
         torch.cuda.set_device(self.device)
+
+        # Start background monitor thread (no-op loop for now).
         threading.Thread(
-            target=self.run, daemon=True, name="WorkerSentinelMonitorThread"
+            target=self.run, daemon=True, name="WorkerSentinelThread"
         ).start()
 
     def run(self):
-        # Wait for fault tolerance instructions from EngineCoreSentinel
-        while not self.sentinel_dead:
-            self.receive_and_execute_upstream_cmd()
+        """
+        Placeholder run loop for WorkerSentinel.
 
-    def pause(self, timeout: int = 1, **kwargs) -> bool:
-        soft_pause = kwargs.get("soft_pause", False)
-        if soft_pause:
-            self._set_device_communicator_status(False)
-            self.pause_event.set()
-            self.logger("Pause signal sent.")
-            return True
-        # Abort all NCCL communicators and
-        # process groups in parallel using a thread pool.
-        if self.communicator_aborted:
-            return True
-        self.pause_event.set()
-        self._set_device_communicator_status(False)
-        torch.cuda.set_device(self.device)
-        model_groups = get_all_model_groups()
-        futures = []
-
-        def _abort_nccl_comm(group: GroupCoordinator):
-            if group.device_communicator is not None:
-                device_comm = cast(CudaCommunicator, group.device_communicator)
-                nccl_comm = device_comm.pynccl_comm
-                assert nccl_comm is not None
-                nccl_comm.nccl_abort_comm()
-
-        def _abort_process_group(group: GroupCoordinator):
-            device = torch.device("cuda")
-            backend = group.device_group._get_backend(device)
-            backend.abort()
-
-        executor = ThreadPoolExecutor(max_workers=len(model_groups) * 2)
+        Current PR only implements fault-report plumbing; worker-side
+        fault handling is intentionally left as a no-op. This loop keeps
+        the sentinel alive and responsive to shutdown requests. In the
+        follow-up PR we will listen for commands from EngineCoreSentinel
+        and execute reconfiguration/sleep/wake actions here.
+        """
         try:
-            for group in model_groups:
-                futures.append(executor.submit(_abort_nccl_comm, group))
-                futures.append(executor.submit(_abort_process_group, group))
-
-            done, not_done = wait(futures, timeout=timeout, return_when=FIRST_EXCEPTION)
-            if not_done:
-                self.logger(
-                    "%d abort calls did not finish in total %s seconds",
-                    len(not_done),
-                    timeout,
-                    level="warning",
-                )
+            while not self.sentinel_dead:
+                # Sleep briefly to avoid busy loop while still being responsive.
+                time.sleep(1)
         finally:
-            executor.shutdown(wait=False, cancel_futures=True)
-
-        exception_count = sum(1 for f in done if f.exception() is not None)
-        self.communicator_aborted = len(not_done) == 0 and exception_count == 0
-        if self.communicator_aborted:
-            cleanup_dist_env_and_memory()
-            self.logger("Communicators are aborted.")
-        else:
-            self.logger(
-                "Communicator abort failed: %d NCCL comm abort calls timed out,"
-                " %d tasks threw exceptions. This may leave NCCL communicators "
-                "or process groups in an inconsistent state. Subsequent "
-                "distributed operations could be unsafe.",
-                len(not_done),
-                exception_count,
-                level="error",
-            )
-        return self.communicator_aborted
-
-    def _set_device_communicator_status(self, active: bool):
-        model_groups = get_all_model_groups()
-        for group in model_groups:
-            if group.device_communicator is not None:
-                device_comm = cast(CudaCommunicator, group.device_communicator)
-                nccl_comm = device_comm.pynccl_comm
-                assert nccl_comm is not None
-                nccl_comm.available = active
-                nccl_comm.disabled = not active
-
-    def retry(self, timeout: int = 1, **kwargs) -> bool:
-        # todo: fix why DP1~3 occupies memory on the first GPU
-        if self.communicator_aborted:
-            torch.cuda.set_device(self.device)
-            with set_current_vllm_config(self.vllm_config):
-                self.init_distributed_env_callback()
-                self.communicator_aborted = False
-            torch.cuda.synchronize()
-        self.clear_input_batch_callback()
-        self.pause_event.clear()
-        return True
+            self.logger("WorkerSentinel exiting.", level="info")
 
 
 class Worker(WorkerBase):
@@ -447,26 +362,8 @@ class Worker(WorkerBase):
             report_usage_stats(self.vllm_config)
 
         if self.vllm_config.fault_tolerance_config.enable_fault_tolerance:
-            with set_current_vllm_config(self.vllm_config):
-                init_distributed_env_callback = partial(
-                    init_worker_distributed_environment,
-                    self.vllm_config,
-                    self.rank,
-                    self.distributed_init_method,
-                    self.local_rank,
-                )
-
-            def clear_input_batch_callback():
-                input_batch = self.model_runner.input_batch
-                cached_req_ids = input_batch.req_id_to_index.keys()
-                for req_id in list(cached_req_ids):
-                    input_batch.remove_request(req_id)
-
             self.worker_sentinel = WorkerSentinel(
                 self.vllm_config,
-                self.model_runner.pause_event,
-                init_distributed_env_callback,
-                clear_input_batch_callback,
                 self.device,
             )
 
@@ -1282,12 +1179,7 @@ def init_worker_distributed_environment(
 
     init_method = distributed_init_method or "env://"
     init_distributed_environment(
-        parallel_config.world_size,
-        rank,
-        init_method,
-        local_rank,
-        backend,
-        fault_tolerance_config=vllm_config.fault_tolerance_config,
+        parallel_config.world_size, rank, init_method, local_rank, backend
     )
 
     ensure_model_parallel_initialized(
@@ -1295,7 +1187,6 @@ def init_worker_distributed_environment(
         parallel_config.pipeline_parallel_size,
         parallel_config.prefill_context_parallel_size,
         parallel_config.decode_context_parallel_size,
-        fault_tolerance_config=vllm_config.fault_tolerance_config,
     )
 
     # Init ec connector here before KV caches caches init


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Split the fault tolerance framework PR into three parts: **fault report**, **pause-on-error**, and **fault-handling**. This PR is the first part. It removes the latter two parts from the existing code and retains only the fault report functionality. Currently, when an error occurs, the engine core does not exit immediately. Instead, it waits for a preconfigured **engine_recovery_timeout** period while reporting the exception. The exception details and the health status of each DP rank are then delivered to the client through API interfaces and a ZMQ PUB interface.


## Test Plan
Only DT has been tested so far. Real-machine testing will be conducted later.
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

