### PR TITLE
Unify engine process monitoring in engine manager and add Ray backend support

### DIFF
--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -208,8 +208,11 @@ def run_headless(args: argparse.Namespace):
         log_stats=not engine_args.disable_log_stats,
     )
 
+    def callback(*_, **__):
+        engine_manager.shutdown_monitor = True
+
     try:
-        engine_manager.join_first()
+        engine_manager.monitor_engine_liveness(callback)
     finally:
         logger.info("Shutting down.")
         engine_manager.close()

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
 import contextlib
-import multiprocessing
 import queue
 import sys
 import uuid
@@ -659,41 +658,24 @@ class MPClient(EngineCoreClient):
     def start_engine_core_monitor(self):
         """Start a monitor thread for engine core processes."""
         engine_manager = self.resources.engine_manager
-        if (
-            engine_manager is None
-            or not hasattr(engine_manager, "processes")
-            or not engine_manager.processes
-        ):
-            # No engine processes to monitor
+        if engine_manager is None:
             return
 
-        engine_processes = engine_manager.processes
         self_ref = weakref.ref(self)
 
-        # Monitor engine core process liveness. If any die unexpectedly,
-        # logs an error, shuts down the client and invokes the failure
-        # callback to inform the engine.
-        def monitor_engine_cores():
-            sentinels = [proc.sentinel for proc in engine_processes]
-            died = multiprocessing.connection.wait(sentinels)
+        def shutdown_callback(*_, **__):
             _self = self_ref()
             if not _self or _self.resources.engine_dead:
                 return
             _self.resources.engine_dead = True
-            proc_name = next(
-                proc.name for proc in engine_processes if proc.sentinel == died[0]
-            )
-            logger.error(
-                "Engine core proc %s died unexpectedly, shutting down client.",
-                proc_name,
-            )
+            engine_manager.shutdown_monitor = True
             _self.shutdown()
-            # Note: For MPClient, we don't have a failure callback mechanism
-            # like MultiprocExecutor, but we set engine_dead flag which will
-            # cause subsequent operations to raise EngineDeadError
 
         Thread(
-            target=monitor_engine_cores, daemon=True, name="MPClientEngineMonitor"
+            target=engine_manager.monitor_engine_liveness,
+            args=(shutdown_callback,),
+            daemon=True,
+            name="MPClientEngineMonitor",
         ).start()
 
 

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from multiprocessing import Process, connection
 from multiprocessing.process import BaseProcess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 import msgspec
@@ -129,6 +129,7 @@ class CoreEngineProcManager:
             )
 
         self._finalizer = weakref.finalize(self, shutdown, self.processes)
+        self.shutdown_monitor = False
 
         data_parallel = vllm_config.parallel_config.data_parallel_size > 1
         try:
@@ -155,11 +156,46 @@ class CoreEngineProcManager:
 
     def close(self):
         """Shutdown all procs."""
+        self.shutdown_monitor = True
         self._finalizer()
 
-    def join_first(self):
-        """Wait for any process to exit."""
-        connection.wait(proc.sentinel for proc in self.processes)
+    def monitor_engine_liveness(
+        self,
+        engine_down_callback: Callable[..., None] | None = None,
+    ) -> None:
+        """
+        Monitor engine core process liveness.
+
+        Args:
+            engine_down_callback:
+                Optional callback invoked once for each detected dead process.
+                The callback is called with keyword arguments:
+                    dead_proc: The process that exited.
+                    all_processes: The full list of engine processes.
+        """
+
+        sentinel_to_proc = {proc.sentinel: proc for proc in self.processes}
+        sentinels = set(sentinel_to_proc.keys())
+
+        while sentinels and not self.shutdown_monitor:
+            died_sentinels = connection.wait(sentinels, timeout=1)
+
+            for sentinel in died_sentinels:
+                proc = sentinel_to_proc[cast(int, sentinel)]
+                exitcode = proc.exitcode
+                if exitcode != 0:
+                    logger.error(
+                        "Engine core proc %s died unexpectedly.",
+                        proc.name,
+                    )
+
+                if engine_down_callback is not None:
+                    engine_down_callback(
+                        dead_proc=proc,
+                        all_processes=self.processes,
+                    )
+
+            sentinels -= set(died_sentinels)
 
     def sentinels(self) -> list:
         return [proc.sentinel for proc in self.processes]
@@ -271,6 +307,7 @@ class CoreEngineActorManager:
         self.log_stats = log_stats
         local_engine_count = vllm_config.parallel_config.data_parallel_size_local
         world_size = vllm_config.parallel_config.world_size
+        self.shutdown_monitor = False
 
         if ray.is_initialized():
             logger.info("Ray is already initialized. Skipping Ray initialization.")
@@ -768,9 +805,37 @@ class CoreEngineActorManager:
     def get_run_refs(self):
         return self.run_refs
 
+    def monitor_engine_liveness(
+        self,
+        engine_down_callback: Callable[..., None] | None = None,
+    ) -> None:
+        import ray
+
+        processed_done_refs: set[ray.ObjectRef] = set()
+        while not self.shutdown_monitor:
+            actor_run_refs = set(self.get_run_refs())
+            if not actor_run_refs:
+                logger.info(
+                    "There are no actors to monitor currently. "
+                    "The monitoring function is about to terminate."
+                )
+                break
+
+            refs_to_watch = list(actor_run_refs - processed_done_refs)
+            actor_done_refs, _ = ray.wait(refs_to_watch, timeout=5)
+            for actor_ref in actor_done_refs:
+                logger.error("Engine core actor died: %s", actor_ref)
+                if engine_down_callback is not None:
+                    engine_down_callback(
+                        dead_proc=actor_ref, all_processes=list(actor_run_refs)
+                    )
+
+                processed_done_refs.add(actor_ref)
+
     def close(self):
         import ray
 
+        self.shutdown_monitor = True
         for actor in self.local_engine_actors + self.remote_engine_actors:
             ray.kill(actor)
         for pg in self.created_placement_groups:

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -242,7 +242,7 @@ def wait_for_completion_or_failure(
         coordinator: The coordinator for data parallel.
     """
 
-    from vllm.v1.engine.utils import CoreEngineActorManager, CoreEngineProcManager
+    import threading
 
     try:
         logger.info("Waiting for API servers to complete ...")
@@ -255,15 +255,31 @@ def wait_for_completion_or_failure(
         if coordinator:
             sentinel_to_proc[coordinator.proc.sentinel] = coordinator.proc
 
-        actor_run_refs = []
-        if isinstance(engine_manager, CoreEngineProcManager):
-            for proc in engine_manager.processes:
-                sentinel_to_proc[proc.sentinel] = proc
-        elif isinstance(engine_manager, CoreEngineActorManager):
-            actor_run_refs = engine_manager.get_run_refs()
+        # start monitor for engine liveness
+        if engine_manager:
+            engine_dead_event = threading.Event()
+            dead_msg: str | None = None
+
+            def engine_down_callback(dead_proc, all_processes: list):
+                nonlocal dead_msg
+                assert engine_manager is not None
+                engine_dead_event.set()
+                dead_engine_index = all_processes.index(dead_proc)
+                dead_msg = f"Engine core process {dead_engine_index} is dead."
+                engine_manager.shutdown_monitor = True
+
+            monitor_thread = threading.Thread(
+                target=engine_manager.monitor_engine_liveness,
+                args=(engine_down_callback,),
+                daemon=True,
+            )
+            monitor_thread.start()
 
         # Check if any process terminates
-        while sentinel_to_proc or actor_run_refs:
+        while sentinel_to_proc:
+            if engine_manager is not None and engine_dead_event.is_set():
+                assert dead_msg is not None
+                raise RuntimeError(dead_msg)
             # Wait for any process to terminate
             ready_sentinels: list[Any] = connection.wait(sentinel_to_proc, timeout=5)
 
@@ -277,11 +293,6 @@ def wait_for_completion_or_failure(
                         f"Process {proc.name} (PID: {proc.pid}) "
                         f"died with exit code {proc.exitcode}"
                     )
-
-            if actor_run_refs:
-                import ray
-
-                _, actor_run_refs = ray.wait(actor_run_refs, timeout=5)
 
     except KeyboardInterrupt:
         logger.info("Received KeyboardInterrupt, shutting down API servers...")


### PR DESCRIPTION
## Purpose
vLLM currently monitors the liveness of engine core processes, but the implementation is separated across different launch modes. The monitoring logic is scattered and inconsistent, and some execution paths are not fully supported:

- The `data-parallel-backend=ray` path does not implement equivalent engine liveness monitoring.
- In headless mode, engine process exit does not provide clear additional signals or structured handling.
- 
This PR addresses these issues by:

1. Centralizing engine process monitoring logic in `CoreEngineProcManager`, ensuring consistent behavior across different launch modes and backends.
2. Adding support for the Ray backend in `CoreEngineActorManager`, so engine core process termination is properly detected and handled.
3. Introducing an `engine_down_callback` hook, which is triggered when an engine process exits.

```
    def monitor_engine_liveness(
        self,
        engine_down_callback: Callable[..., None] | None = None,
    ) -> None:
```

- It can be used to shut down the entire vLLM service when a critical engine process exits.
- It lays the groundwork for future fault-tolerant EP support, where one process exit may require coordinated handling (e.g., preventing other processes from hanging and enabling controlled recovery).

**Overall, this change unifies behavior, improves robustness, and provides a clear extension point for future fault tolerance mechanisms.**

## Test Result
1. Tested with:
  - Model: Qwen3-30B
  - Parallelism: DP=4, TP=1
  - Backends:
    - mp
    - ray

2. Test procedure: Manually kill one engine core process.
3. Verify that:
  - Appropriate "engine process dead" logs are emitted.
  - Behavior is consistent across both MP and Ray backends.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

