### PR TITLE
external-lb-eep

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -695,6 +695,7 @@ class ParallelConfig:
             "data_parallel_master_ip",
             "data_parallel_master_port",
             "_data_parallel_master_port_list",
+            "_coord_store_port",
             "data_parallel_rpc_port",
             "rank",
             "master_addr",
@@ -739,11 +740,11 @@ class ParallelConfig:
                     "Elastic EP is not supported with pipeline parallelism "
                     f"(pipeline_parallel_size={self.pipeline_parallel_size})."
                 )
-            if self.data_parallel_external_lb or self.data_parallel_hybrid_lb:
+            if self.data_parallel_hybrid_lb:
                 raise NotImplementedError(
-                    "Elastic EP is not compatible with data_parallel_external_lb "
-                    "or data_parallel_hybrid_lb. Elastic EP relies on a single API "
-                    "server and core client to coordinate scale up/down."
+                    "Elastic EP is not compatible with data_parallel_hybrid_lb. "
+                    "Elastic EP supports a single API server/core client path "
+                    "or data_parallel_external_lb, but not hybrid load balancing."
                 )
 
         if self.data_parallel_size > 1 or self.data_parallel_size_local == 0:

--- a/vllm/distributed/elastic_ep/elastic_state.py
+++ b/vllm/distributed/elastic_ep/elastic_state.py
@@ -528,10 +528,14 @@ class ElasticEPScalingState:
         self.engine_core.engines_running = bool(data[0])
         self.engine_core.current_wave = int(data[1])
         self.engine_core.step_counter = int(data[2])
-        if new_dp_group.rank() == 0:
+        if (
+            new_dp_group.rank() == 0
+            or self.vllm_config.parallel_config.data_parallel_external_lb
+        ):
             self.engine_core._eep_send_engine_core_notification(
                 EEPNotificationType.RECONFIGURE_FINISHED
             )
+        if new_dp_group.rank() == 0:
             logger.info("[Elastic EP] Switched to new setup")
 
     def _eplb_reshuffle(self):

--- a/vllm/distributed/elastic_ep/external_elastic_ep.py
+++ b/vllm/distributed/elastic_ep/external_elastic_ep.py
@@ -1,0 +1,604 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import contextlib
+from collections.abc import Sequence
+from threading import Event, Thread
+from typing import TYPE_CHECKING, Any
+
+import msgspec
+import msgspec.msgpack
+import zmq
+
+from vllm.logger import init_logger
+from vllm.utils.network_utils import make_zmq_socket
+from vllm.v1.engine import (
+    EEPNotificationType,
+    ReconfigureDistributedRequest,
+    ReconfigureRankType,
+)
+from vllm.v1.engine.utils import EngineHandshakeMetadata, EngineZmqAddresses
+from vllm.v1.utils import get_engine_client_zmq_addr
+
+if TYPE_CHECKING:
+    from vllm.v1.engine.core_client import DPAsyncMPClient
+
+logger = init_logger(__name__)
+
+
+class ExternalElasticEPScaleUpHandshakeServer:
+    """Temporary rank-0 handshake server for external EEP scale-up.
+
+    During normal external startup the global handshake listener only exists
+    while the rank starts. Scale-up needs the same handshake contract again for
+    newly launched ranks, so rank 0 re-opens a temporary listener for the
+    duration of the current scale operation.
+
+    The handshake gives new ranks the information they cannot infer locally:
+    front-end and DP coordinator ZMQ addresses, the new DP master address/ports,
+    target DP size, and the coordination store port used for EEP
+    reconfiguration.
+    """
+
+    def __init__(
+        self,
+        *,
+        handshake_address: str,
+        expected_new_ranks: list[int],
+        addresses: EngineZmqAddresses,
+        bootstrap: ReconfigureDistributedRequest,
+    ) -> None:
+        self.handshake_address = handshake_address
+        self.expected_new_ranks = set(expected_new_ranks)
+        self.addresses = addresses
+        self.bootstrap = bootstrap
+        self.started_event = Event()
+        self._stop_event = Event()
+        self._thread = Thread(
+            target=self._run,
+            name="ExternalElasticEPHandshakeServer",
+            daemon=True,
+        )
+        self._error: Exception | None = None
+
+    def start(self) -> None:
+        self._thread.start()
+        started = self.started_event.wait(timeout=5)
+        if self._error is not None:
+            raise self._error
+        if not started:
+            raise TimeoutError(
+                "Timed out waiting for external EEP handshake server to "
+                f"start listening at {self.handshake_address}"
+            )
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=5)
+        if self._error is not None:
+            raise self._error
+
+    def _run(self) -> None:
+        pending_ready_ranks = self.expected_new_ranks.copy()
+        try:
+            with (
+                zmq.Context() as ctx,
+                make_zmq_socket(
+                    ctx,
+                    self.handshake_address,
+                    zmq.ROUTER,
+                    bind=True,
+                    linger=0,
+                    router_handover=True,
+                ) as handshake_socket,
+            ):
+                self.started_event.set()
+                poller = zmq.Poller()
+                poller.register(handshake_socket, zmq.POLLIN)
+
+                while not self._stop_event.is_set():
+                    if not pending_ready_ranks:
+                        return
+
+                    events = dict(poller.poll(timeout=1000))
+                    if handshake_socket not in events:
+                        continue
+
+                    engine_identity, payload = handshake_socket.recv_multipart()
+                    engine_rank = int.from_bytes(engine_identity, "little")
+                    if engine_rank not in self.expected_new_ranks:
+                        raise RuntimeError(
+                            "Received scale-up handshake from unexpected "
+                            f"dp rank {engine_rank}"
+                        )
+
+                    message = msgspec.msgpack.decode(payload)
+                    status = message["status"]
+                    if status == "HELLO":
+                        b = self.bootstrap
+                        parallel_config: dict[str, int | str | list[int]] = {
+                            "data_parallel_master_ip": b.new_data_parallel_master_ip,
+                            "data_parallel_master_port": (
+                                b.new_data_parallel_master_port
+                            ),
+                            "_data_parallel_master_port_list": (
+                                b.new_data_parallel_master_port_list
+                            ),
+                            "data_parallel_size": b.new_data_parallel_size,
+                            "_coord_store_port": b.coord_store_port,
+                        }
+                        init_message = msgspec.msgpack.encode(
+                            EngineHandshakeMetadata(
+                                addresses=self.addresses,
+                                parallel_config=parallel_config,
+                            )
+                        )
+                        handshake_socket.send_multipart(
+                            (engine_identity, init_message), copy=False
+                        )
+                    elif status == "READY":
+                        pending_ready_ranks.discard(engine_rank)
+                    else:
+                        raise RuntimeError(
+                            f"Unexpected handshake status {status} from dp rank "
+                            f"{engine_rank}"
+                        )
+        except Exception as e:
+            self._error = e
+            self.started_event.set()
+
+
+class ExternalElasticEPScaleCoordinator:
+    def __init__(self, client: "DPAsyncMPClient") -> None:
+        self.client = client
+        self.active_reconfig_store: tuple[str, int] | None = None
+        # Keep the previous rank-0 TCPStore server alive while the next scale
+        # operation publishes bootstrap metadata through it. Overwriting
+        # client._coord_store with the new store can otherwise close the old
+        # server while other ranks are still polling it.
+        self.control_store_ref: Any | None = None
+        self.reconfig_store_ref: Any | None = None
+
+    @staticmethod
+    def key(*parts: str | int) -> str:
+        return "/".join(["elastic_ep/external", *[str(part) for part in parts]])
+
+    def _update_parallel_config(self, bootstrap: ReconfigureDistributedRequest) -> None:
+        parallel_config = self.client.vllm_config.parallel_config
+        parallel_config.data_parallel_size = bootstrap.new_data_parallel_size
+        parallel_config.data_parallel_master_ip = bootstrap.new_data_parallel_master_ip
+        parallel_config.data_parallel_master_port = (
+            bootstrap.new_data_parallel_master_port
+        )
+        parallel_config._data_parallel_master_port_list = (
+            bootstrap.new_data_parallel_master_port_list.copy()
+        )
+        parallel_config._coord_store_port = bootstrap.coord_store_port
+
+    def _get_reconfig_store(self):
+        from vllm.distributed.utils import get_cached_tcp_store_client
+
+        if self.active_reconfig_store is not None:
+            store_addr = self.active_reconfig_store
+        else:
+            parallel_config = self.client.vllm_config.parallel_config
+            if not parallel_config._coord_store_port:
+                raise RuntimeError(
+                    "External Elastic EP requires an active reconfiguration "
+                    "coordination store."
+                )
+            store_addr = (
+                parallel_config.data_parallel_master_ip,
+                parallel_config._coord_store_port,
+            )
+
+        return get_cached_tcp_store_client(*store_addr)
+
+    def _get_existing_engine_zmq_address(self) -> EngineZmqAddresses:
+        coordinator = self.client.resources.coordinator
+        if coordinator is None:
+            raise RuntimeError(
+                "External Elastic EP scale-up requires rank 0 to own a DP coordinator."
+            )
+        coordinator_input, coordinator_output = (
+            coordinator.get_engine_socket_addresses()
+        )
+        stats_publish_address = coordinator.get_stats_publish_address()
+
+        input_endpoint = self.client.input_socket.getsockopt_string(zmq.LAST_ENDPOINT)
+        output_socket = self.client.resources.output_socket
+        output_endpoint = (
+            output_socket.getsockopt_string(zmq.LAST_ENDPOINT)
+            if output_socket is not None
+            else ""
+        )
+
+        return EngineZmqAddresses(
+            inputs=[input_endpoint],
+            outputs=[output_endpoint],
+            coordinator_input=coordinator_input,
+            coordinator_output=coordinator_output,
+            frontend_stats_publish_address=stats_publish_address,
+        )
+
+    def _setup_reconfig_bootstrap(self) -> tuple[str, int]:
+        from vllm.distributed.utils import create_tcp_store
+        from vllm.utils.network_utils import get_open_ports_list
+
+        parallel_config = self.client.vllm_config.parallel_config
+        parallel_config._data_parallel_master_port_list = get_open_ports_list(5)
+        parallel_config.data_parallel_master_port = (
+            parallel_config._data_parallel_master_port_list.pop()
+        )
+
+        ip = parallel_config.data_parallel_master_ip
+        store = create_tcp_store(
+            ip,
+            0,
+            is_master=True,
+            world_size=-1,
+            wait_for_workers=False,
+        )
+        parallel_config._coord_store_port = store.port
+        self.reconfig_store_ref = store
+        self.control_store_ref = getattr(self.client, "_coord_store", None)
+        self.client._coord_store = store
+        return ip, store.port
+
+    def _get_error(self, store: Any) -> str | None:
+        error_key = self.key("error")
+        if not store.check([error_key]):
+            return None
+        return store.get(error_key).decode()
+
+    def _cleanup_reconfig_keys(
+        self,
+        store: Any,
+        max_data_parallel_size: int,
+    ) -> None:
+        keys = [
+            self.key("bootstrap"),
+            self.key("prepared"),
+            self.key("completed"),
+            self.key("error"),
+        ]
+        for rank in range(max_data_parallel_size):
+            keys.append(self.key("old_rank_finished", rank))
+            keys.append(self.key("shutdown_complete", rank))
+            for notification_type in (
+                EEPNotificationType.NEW_CORE_ENGINES_INIT_READY,
+                EEPNotificationType.NEW_CORE_ENGINES_WEIGHTS_INIT_READY,
+            ):
+                keys.append(self.key("notifications", notification_type.value, rank))
+
+        for key in keys:
+            with contextlib.suppress(Exception):
+                store.delete_key(key)
+
+    async def _wait_for_bootstrap(
+        self,
+        store: Any,
+        requested_new_dp_size: int,
+        timeout_s: float = 300,
+    ) -> ReconfigureDistributedRequest:
+        """Wait for rank 0 to publish matching scale bootstrap metadata.
+        Non-zero ranks poll the old control store until prepared or errored."""
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        bootstrap_key = self.key("bootstrap")
+        prepared_key = self.key("prepared")
+        completed_key = self.key("completed")
+        while True:
+            error = self._get_error(store)
+            if error is not None:
+                raise RuntimeError(error)
+
+            if store.check([bootstrap_key]):
+                bootstrap = msgspec.msgpack.decode(
+                    store.get(bootstrap_key),
+                    type=ReconfigureDistributedRequest,
+                )
+                completed = store.check([completed_key])
+                if bootstrap.new_data_parallel_size != requested_new_dp_size:
+                    if store.check([prepared_key]) and not completed:
+                        raise RuntimeError(
+                            "A different external Elastic EP scaling operation is "
+                            f"already in progress for target dp size "
+                            f"{bootstrap.new_data_parallel_size}."
+                        )
+                elif store.check([prepared_key]):
+                    return bootstrap
+
+            now = loop.time()
+            if now - start > timeout_s:
+                raise TimeoutError(
+                    "Timed out waiting for rank 0 to publish external Elastic EP "
+                    "bootstrap metadata."
+                )
+            await asyncio.sleep(0.1)
+
+    def _prepare_reconfig_bootstrap(
+        self,
+        store: Any,
+        cur_data_parallel_size: int,
+        new_data_parallel_size: int,
+    ) -> ReconfigureDistributedRequest:
+        current_error = self._get_error(store)
+        if (
+            current_error is None
+            and store.check([self.key("prepared")])
+            and not (store.check([self.key("completed")]))
+        ):
+            raise RuntimeError(
+                "Another external Elastic EP scaling operation is already active."
+            )
+
+        self._cleanup_reconfig_keys(
+            store, max(cur_data_parallel_size, new_data_parallel_size)
+        )
+        ip, coord_store_port = self._setup_reconfig_bootstrap()
+        parallel_config = self.client.vllm_config.parallel_config
+        bootstrap = ReconfigureDistributedRequest(
+            new_data_parallel_size=new_data_parallel_size,
+            new_data_parallel_rank=ReconfigureRankType.KEEP_CURRENT_RANK,
+            new_data_parallel_rank_local=ReconfigureRankType.KEEP_CURRENT_RANK,
+            new_data_parallel_master_ip=ip,
+            new_data_parallel_master_port=parallel_config.data_parallel_master_port,
+            new_data_parallel_master_port_list=(
+                parallel_config._data_parallel_master_port_list.copy()
+            ),
+            coord_store_port=coord_store_port,
+        )
+
+        bootstrap_key = self.key("bootstrap")
+        store.set(bootstrap_key, msgspec.msgpack.encode(bootstrap))
+        return bootstrap
+
+    def _start_scale_up_handshake_server(
+        self,
+        bootstrap: ReconfigureDistributedRequest,
+        cur_data_parallel_size: int,
+    ) -> ExternalElasticEPScaleUpHandshakeServer:
+        handshake_server = ExternalElasticEPScaleUpHandshakeServer(
+            handshake_address=get_engine_client_zmq_addr(
+                False,
+                bootstrap.new_data_parallel_master_ip,
+                self.client.vllm_config.parallel_config.data_parallel_rpc_port,
+            ),
+            expected_new_ranks=list(
+                range(
+                    cur_data_parallel_size,
+                    bootstrap.new_data_parallel_size,
+                )
+            ),
+            addresses=self._get_existing_engine_zmq_address(),
+            bootstrap=bootstrap,
+        )
+        handshake_server.start()
+        return handshake_server
+
+    async def _wait_for_notification(
+        self,
+        control_store: Any,
+        reconfig_store: Any,
+        notification_type: EEPNotificationType,
+        source_ranks: Sequence[int],
+        timeout_s: float = 300,
+    ) -> None:
+        """Wait for source ranks to publish a specific scale notification.
+        Once all are ready, forward the notification to existing engines."""
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+
+        def is_ready(rank: int) -> bool:
+            key = self.key("notifications", notification_type.value, rank)
+            return reconfig_store.check([key])
+
+        while True:
+            error = self._get_error(control_store)
+            if error is not None:
+                raise RuntimeError(
+                    error
+                    or "External Elastic EP scaling failed while waiting for "
+                    f"{notification_type.value}."
+                )
+
+            ready_count = sum(1 for rank in source_ranks if is_ready(rank))
+            if ready_count >= len(source_ranks):
+                await self.client.call_utility_async(
+                    "eep_handle_engine_core_notification",
+                    notification_type.value,
+                )
+                return
+
+            now = loop.time()
+            if now - start > timeout_s:
+                raise TimeoutError(
+                    "Timed out waiting for external Elastic EP notification "
+                    f"{notification_type.value}."
+                )
+            await asyncio.sleep(0.1)
+
+    async def _wait_for_local_reconfig_finished(
+        self,
+        control_store: Any,
+        reconfig_store: Any,
+        bootstrap: ReconfigureDistributedRequest,
+        dp_rank: int,
+        scale_up: bool,
+        timeout_s: float = 600,
+    ) -> None:
+        """Wait until this rank's EngineCore finishes the scale transition."""
+        if not scale_up and dp_rank >= bootstrap.new_data_parallel_size:
+            wait_key = self.key("shutdown_complete", dp_rank)
+            timeout_msg = (
+                "Timed out waiting for local external Elastic EP scale-down "
+                "shutdown to finish."
+            )
+        else:
+            wait_key = self.key("old_rank_finished", dp_rank)
+            timeout_msg = (
+                "Timed out waiting for local external Elastic EP "
+                "reconfiguration to finish."
+            )
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        while True:
+            error = self._get_error(control_store)
+            if error is not None:
+                raise RuntimeError(
+                    error or "External Elastic EP scaling failed on another rank."
+                )
+
+            if reconfig_store.check([wait_key]):
+                return
+
+            now = loop.time()
+            if now - start > timeout_s:
+                raise TimeoutError(timeout_msg)
+            await asyncio.sleep(0.1)
+
+    async def scale(
+        self, cur_data_parallel_size: int, new_data_parallel_size: int
+    ) -> None:
+        from vllm.distributed.utils import get_cached_tcp_store_client
+
+        parallel_config = self.client.vllm_config.parallel_config
+        dp_rank = parallel_config.data_parallel_rank
+        scale_up = new_data_parallel_size > cur_data_parallel_size
+        if not parallel_config._coord_store_port:
+            raise RuntimeError(
+                "External Elastic EP requires a runtime coordination store port."
+            )
+        control_store = get_cached_tcp_store_client(
+            parallel_config.data_parallel_master_ip,
+            parallel_config._coord_store_port,
+        )
+        handshake_server: ExternalElasticEPScaleUpHandshakeServer | None = None
+        bootstrap: ReconfigureDistributedRequest | None = None
+
+        try:
+            if dp_rank == 0:
+                bootstrap = self._prepare_reconfig_bootstrap(
+                    control_store,
+                    cur_data_parallel_size,
+                    new_data_parallel_size,
+                )
+                if scale_up:
+                    handshake_server = self._start_scale_up_handshake_server(
+                        bootstrap, cur_data_parallel_size
+                    )
+                control_store.set(self.key("prepared"), b"1")
+            else:
+                bootstrap = await self._wait_for_bootstrap(
+                    control_store, new_data_parallel_size
+                )
+
+            self.active_reconfig_store = (
+                bootstrap.new_data_parallel_master_ip,
+                bootstrap.coord_store_port,
+            )
+            reconfig_store = self._get_reconfig_store()
+
+            reconfig_rank = (
+                ReconfigureRankType.SHUTDOWN_CURRENT_RANK
+                if not scale_up and dp_rank >= bootstrap.new_data_parallel_size
+                else ReconfigureRankType.KEEP_CURRENT_RANK
+            )
+            reconfig_request = ReconfigureDistributedRequest(
+                new_data_parallel_size=bootstrap.new_data_parallel_size,
+                new_data_parallel_rank=reconfig_rank,
+                new_data_parallel_rank_local=ReconfigureRankType.KEEP_CURRENT_RANK,
+                new_data_parallel_master_ip=bootstrap.new_data_parallel_master_ip,
+                new_data_parallel_master_port=bootstrap.new_data_parallel_master_port,
+                new_data_parallel_master_port_list=(
+                    bootstrap.new_data_parallel_master_port_list
+                ),
+                coord_store_port=bootstrap.coord_store_port,
+            )
+            await self.client.call_utility_async(
+                "reinitialize_distributed", reconfig_request
+            )
+
+            if scale_up:
+                new_ranks = list(
+                    range(
+                        cur_data_parallel_size,
+                        bootstrap.new_data_parallel_size,
+                    )
+                )
+                await self._wait_for_notification(
+                    control_store,
+                    reconfig_store,
+                    EEPNotificationType.NEW_CORE_ENGINES_INIT_READY,
+                    new_ranks,
+                )
+                await self._wait_for_notification(
+                    control_store,
+                    reconfig_store,
+                    EEPNotificationType.NEW_CORE_ENGINES_WEIGHTS_INIT_READY,
+                    new_ranks,
+                )
+
+            await self._wait_for_local_reconfig_finished(
+                control_store,
+                reconfig_store,
+                bootstrap,
+                dp_rank,
+                scale_up,
+            )
+            if dp_rank == 0:
+                control_store.set(self.key("completed"), b"1")
+            if scale_up or dp_rank < bootstrap.new_data_parallel_size:
+                self._update_parallel_config(bootstrap)
+        except Exception as e:
+            if bootstrap is not None:
+                control_store.set(
+                    self.key("error"),
+                    str(e).encode(),
+                )
+            raise
+        finally:
+            if handshake_server is not None:
+                with contextlib.suppress(Exception):
+                    handshake_server.stop()
+
+    async def process_engine_core_notification(
+        self, notification_data: tuple[str, int]
+    ) -> None:
+        """Record scale notifications emitted by EngineCore processes.
+        The stored keys are later polled by the external scale coordinator."""
+        parallel_config = self.client.vllm_config.parallel_config
+        if not (
+            parallel_config.enable_elastic_ep
+            and parallel_config.data_parallel_external_lb
+        ):
+            return
+
+        notification_type_str, dp_rank = notification_data
+        notification_type = EEPNotificationType(notification_type_str)
+        if not parallel_config._coord_store_port:
+            logger.warning(
+                "Ignoring external Elastic EP notification %s because coord "
+                "store metadata is not available yet.",
+                notification_type.value,
+            )
+            return
+
+        reconfig_store = self._get_reconfig_store()
+
+        if notification_type in (
+            EEPNotificationType.NEW_CORE_ENGINES_INIT_READY,
+            EEPNotificationType.NEW_CORE_ENGINES_WEIGHTS_INIT_READY,
+        ):
+            key = self.key("notifications", notification_type.value, dp_rank)
+            reconfig_store.set(key, b"1")
+        elif notification_type == EEPNotificationType.RECONFIGURE_FINISHED:
+            key = self.key("old_rank_finished", dp_rank)
+            reconfig_store.set(key, b"1")
+        elif notification_type == EEPNotificationType.SHUTDOWN_COMPLETE:
+            key = self.key("shutdown_complete", dp_rank)
+            reconfig_store.set(key, b"1")

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -128,6 +128,7 @@ class DPCoordinator:
         self.stats_publish_address = front_publish_address
         self.coord_in_address = back_publish_address
         self.coord_out_address = back_output_address
+        self._coord_store: object | None = None
         self._finalizer = weakref.finalize(self, shutdown, [self.proc])
 
     def get_stats_publish_address(self) -> str:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -972,6 +972,16 @@ class EngineCoreProc(EngineCore):
                 #    (addresses).
                 # 2. Add front-end input/output addresses from colocated front-end
                 #    (client_addresses).
+                if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+                    self.eep_notification_addresses = EngineZmqAddresses(
+                        inputs=addresses.inputs.copy(),
+                        outputs=addresses.outputs.copy(),
+                        coordinator_input=addresses.coordinator_input,
+                        coordinator_output=addresses.coordinator_output,
+                        frontend_stats_publish_address=(
+                            addresses.frontend_stats_publish_address
+                        ),
+                    )
                 addresses.inputs = client_addresses.inputs
                 addresses.outputs = client_addresses.outputs
                 yield addresses
@@ -1014,6 +1024,10 @@ class EngineCoreProc(EngineCore):
             if vllm_config.parallel_config.data_parallel_size > 1:
                 ready_msg["parallel_config_hash"] = (
                     vllm_config.parallel_config.compute_hash()
+                )
+            if vllm_config.parallel_config.enable_elastic_ep:
+                ready_msg["coord_store_port"] = (
+                    vllm_config.parallel_config._coord_store_port
                 )
 
             handshake_socket.send(msgspec.msgpack.encode(ready_msg))
@@ -1864,7 +1878,20 @@ class DPEngineCoreProc(EngineCoreProc):
         )
         outputs.engine_index = self.engine_index
 
-        if hasattr(self, "output_thread") and self.output_thread.is_alive():
+        notification_addresses = getattr(self, "eep_notification_addresses", None)
+        if notification_addresses is not None:
+            encoder = MsgpackEncoder()
+            with (
+                zmq.Context() as ctx,
+                make_zmq_socket(
+                    ctx,
+                    notification_addresses.outputs[0],
+                    zmq.PUSH,
+                    linger=4000,
+                ) as socket,
+            ):
+                socket.send_multipart(encoder.encode(outputs))
+        elif hasattr(self, "output_thread") and self.output_thread.is_alive():
             self.output_queue.put_nowait((0, outputs))
         else:
             encoder = MsgpackEncoder()

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -20,6 +20,9 @@ import zmq
 import zmq.asyncio
 
 from vllm.config import VllmConfig
+from vllm.distributed.elastic_ep.external_elastic_ep import (
+    ExternalElasticEPScaleCoordinator,
+)
 from vllm.envs import VLLM_ENGINE_READY_TIMEOUT_S
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -931,13 +934,16 @@ class AsyncMPClient(MPClient):
         output_handler: (
             Callable[[AsyncMPClient, EngineCoreOutputs], Awaitable[None]] | None
         ) = getattr(self.__class__, "process_engine_outputs", None)
-        _self_ref = weakref.ref(self) if output_handler else None
         output_socket = resources.output_socket
         assert output_socket is not None
 
         notification_callback_handler: (
             Callable[[AsyncMPClient, Sequence[Any]], Any] | None
         ) = getattr(self.__class__, "eep_process_engine_core_notification", None)
+        needs_self_ref = (
+            output_handler is not None or notification_callback_handler is not None
+        )
+        _self_ref = weakref.ref(self) if needs_self_ref else None
 
         async def process_outputs_socket():
             try:
@@ -1148,6 +1154,7 @@ class DPAsyncMPClient(AsyncMPClient):
         client_index: int = 0,
     ):
         self.current_wave = 0
+        self.external_eep_coordinator = ExternalElasticEPScaleCoordinator(self)
 
         super().__init__(
             vllm_config,
@@ -1313,6 +1320,58 @@ class DPAsyncMPClient(AsyncMPClient):
     def get_core_engine_for_request(self, request: EngineCoreRequest):
         return self.core_engine
 
+    def _setup_elastic_ep_reconfig_bootstrap(self) -> tuple[str, int]:
+        from vllm.distributed.utils import create_tcp_store
+        from vllm.utils.network_utils import get_open_ports_list
+
+        parallel_config = self.vllm_config.parallel_config
+        parallel_config._data_parallel_master_port_list = get_open_ports_list(5)
+        parallel_config.data_parallel_master_port = (
+            parallel_config._data_parallel_master_port_list.pop()
+        )
+
+        ip = parallel_config.data_parallel_master_ip
+        store = create_tcp_store(
+            ip,
+            0,
+            is_master=True,
+            world_size=-1,
+            wait_for_workers=False,
+        )
+        parallel_config._coord_store_port = store.port
+        self._coord_store = store
+        return ip, store.port
+
+    @staticmethod
+    async def eep_process_engine_core_notification(
+        self: "DPAsyncMPClient", notification_data: tuple[str, int]
+    ) -> None:
+        await self.external_eep_coordinator.process_engine_core_notification(
+            notification_data
+        )
+
+    async def scale_elastic_ep(self, new_data_parallel_size: int) -> None:
+        cur_data_parallel_size = self.vllm_config.parallel_config.data_parallel_size
+
+        assert new_data_parallel_size != cur_data_parallel_size, (
+            f"new_data_parallel_size {new_data_parallel_size} must be "
+            f"different from cur_data_parallel_size {cur_data_parallel_size}"
+        )
+
+        parallel_config = self.vllm_config.parallel_config
+        if not parallel_config.enable_elastic_ep:
+            raise NotImplementedError(
+                "Elastic EP scaling requires enable_elastic_ep=True."
+            )
+        if not parallel_config.data_parallel_external_lb:
+            raise NotImplementedError(
+                "DPAsyncMPClient only supports Elastic EP scaling in external "
+                "load-balancer mode."
+            )
+        await self.external_eep_coordinator.scale(
+            cur_data_parallel_size, new_data_parallel_size
+        )
+
 
 class DPLBAsyncMPClient(DPAsyncMPClient):
     """Asyncio-compatible client for multi-proc, multi-engine (data parallel)
@@ -1398,8 +1457,9 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
 
     @staticmethod
     async def eep_process_engine_core_notification(
-        self: "DPLBAsyncMPClient", notification_data: tuple[str, int]
-    ):
+        self: "DPAsyncMPClient", notification_data: tuple[str, int]
+    ) -> None:
+        assert isinstance(self, DPLBAsyncMPClient)
         cache = self.eep_scaling_cache
         notification_type_str, dp_rank = notification_data
         try:
@@ -1516,28 +1576,6 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         self.utility_results[EEP_NOTIFICATION_CALL_ID] = future
         self._ensure_output_queue_task()
         await future
-
-    def _setup_elastic_ep_reconfig_bootstrap(self) -> tuple[str, int]:
-        from vllm.distributed.utils import create_tcp_store
-        from vllm.utils.network_utils import get_open_ports_list
-
-        parallel_config = self.vllm_config.parallel_config
-        parallel_config._data_parallel_master_port_list = get_open_ports_list(5)
-        parallel_config.data_parallel_master_port = (
-            parallel_config._data_parallel_master_port_list.pop()
-        )
-
-        ip = parallel_config.data_parallel_master_ip
-        store = create_tcp_store(
-            ip,
-            0,
-            is_master=True,
-            world_size=-1,
-            wait_for_workers=False,
-        )
-        parallel_config._coord_store_port = store.port
-        self._coord_store = store
-        return ip, store.port
 
     async def _scale_up_elastic_ep(
         self, cur_data_parallel_size: int, new_data_parallel_size: int

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -136,6 +136,7 @@ class CoreEngineProcManager:
         self._finalizer = weakref.finalize(self, shutdown, self.processes)
         self.manager_stopped = threading.Event()
         self.failed_proc_name: str | None = None
+        self._coord_store: object | None = None
 
         try:
             for proc, local_dp_rank in zip(self.processes, local_dp_ranks):
@@ -936,7 +937,9 @@ def get_engine_zmq_addresses(
         offline_mode or local_engines_only or (local_engine_count == dp_size)
     )
     # NOTE(yongji): handling scaling from intra-node to inter-node
-    if parallel_config.enable_elastic_ep:
+    if parallel_config.enable_elastic_ep and (
+        not local_engines_only or parallel_config.data_parallel_rank == 0
+    ):
         client_local_only = False
 
     return EngineZmqAddresses(
@@ -994,6 +997,32 @@ def launch_core_engines(
         vllm_config.needs_dp_coordinator and not offline_mode and dp_rank == 0
     )
 
+    coord_store = None
+
+    create_coord_store = (
+        parallel_config.enable_elastic_ep
+        and parallel_config.data_parallel_backend != "ray"
+        and dp_rank == 0
+        and not parallel_config._coord_store_port
+    )
+
+    if create_coord_store:
+        from vllm.distributed.utils import create_tcp_store
+
+        coord_store = create_tcp_store(
+            host,
+            0,
+            is_master=True,
+            world_size=-1,
+            wait_for_workers=False,
+        )
+        parallel_config._coord_store_port = coord_store.port
+        logger.info(
+            "Created Elastic EP coordination TCPStore on %s:%d",
+            host,
+            coord_store.port,
+        )
+
     if run_coordinator:
         coordinator = DPCoordinator(
             parallel_config,
@@ -1008,6 +1037,8 @@ def launch_core_engines(
         )
 
         logger.info("Started DP Coordinator process (PID: %d)", coordinator.proc.pid)
+        if coord_store is not None:
+            coordinator._coord_store = coord_store
     else:
         coordinator = None
 
@@ -1088,6 +1119,13 @@ def launch_core_engines(
         else:
             local_engine_manager = None
 
+        if (
+            coord_store is not None
+            and coordinator is None
+            and (local_engine_manager is not None)
+        ):
+            local_engine_manager._coord_store = coord_store
+
         yield local_engine_manager, coordinator, addresses, tensor_queue
 
         # Now wait for engines to start.
@@ -1097,6 +1135,7 @@ def launch_core_engines(
             engines_to_handshake,
             parallel_config,
             dp_size > 1 and vllm_config.model_config.is_moe,
+            not (local_engines_only and dp_rank > 0),
             vllm_config.cache_config,
             local_engine_manager,
             coordinator.proc if coordinator else None,
@@ -1109,6 +1148,7 @@ def wait_for_engine_startup(
     core_engines: list[CoreEngine],
     parallel_config: ParallelConfig,
     coordinated_dp: bool,
+    send_parallel_config: bool,
     cache_config: CacheConfig,
     proc_manager: CoreEngineProcManager | None,
     coord_process: Process | None,
@@ -1191,20 +1231,30 @@ def wait_for_engine_startup(
 
         if status == "HELLO" and engine.state == CoreEngineState.NEW:
             # Send init message with DP config info.
+            parallel_config_payload: dict[str, int | str | list[int]] = {}
+            if coordinated_dp and send_parallel_config:
+                parallel_config_payload = {
+                    k: getattr(parallel_config, k)
+                    for k in (
+                        "data_parallel_master_ip",
+                        "data_parallel_master_port",
+                        "_data_parallel_master_port_list",
+                        "data_parallel_size",
+                    )
+                }
+                if parallel_config.enable_elastic_ep:
+                    if not parallel_config._coord_store_port:
+                        raise RuntimeError(
+                            "Elastic EP startup requires a coordination TCPStore "
+                            "port before engine handshake."
+                        )
+                    parallel_config_payload["_coord_store_port"] = (
+                        parallel_config._coord_store_port
+                    )
             init_message = msgspec.msgpack.encode(
                 EngineHandshakeMetadata(
                     addresses=addresses,
-                    parallel_config={
-                        k: getattr(parallel_config, k)
-                        for k in (
-                            "data_parallel_master_ip",
-                            "data_parallel_master_port",
-                            "_data_parallel_master_port_list",
-                            "data_parallel_size",
-                        )
-                    }
-                    if coordinated_dp
-                    else {},
+                    parallel_config=parallel_config_payload,
                 )
             )
             handshake_socket.send_multipart((eng_identity, init_message), copy=False)
@@ -1212,6 +1262,10 @@ def wait_for_engine_startup(
             start_pending[0 if local else 1] += 1
             engine.state = CoreEngineState.CONNECTED
         elif status == "READY" and engine.state == CoreEngineState.CONNECTED:
+            coord_store_port = msg.get("coord_store_port")
+            if coord_store_port is not None and local:
+                parallel_config._coord_store_port = coord_store_port
+
             # Validate config hash consistency across DP workers for MoE models.
             if coordinated_dp:
                 worker_config_hash = msg.get("parallel_config_hash")


### PR DESCRIPTION
Co-authored with: @zWaNg3 @fangyuchu 
## Purpose

### Summary

This PR implements external Elastic Expert Parallelism (EEP) scaling orchestration, following the design proposed in RFC #42515.

The existing EEP implementation provides the worker-side mechanism for changing EP/DP topology without restarting all workers. However, some online serving deployments use an external load balancer and externally managed DP rank lifecycle. In that mode, vLLM should not create or remove Ray actors for new ranks. Instead, externally launched ranks need a control path to join the existing EEP scale-up / scale-down transition.

This PR adds that external control path while reusing the existing EEP worker-side state machine and worker operations.

The newly introduced external EEP scale coordinator is a temporary per-scaling-operation control object. It is created only while an external scale-up or scale-down request is being processed, and is released after the transition completes. It is not a long-running coordinator in the serving data path.

### Supported Functionality

* Support external EEP scale-up for `data_parallel_external_lb`.
  * Existing ranks receive `/scale_elastic_ep`.
  * Rank 0 publishes bootstrap metadata for the new topology.
  * Externally launched new ranks join through the temporary scale-up handshake path.
  * Existing EEP logic transfers expert state, syncs KV cache capacity, switches groups, and runs EPLB reshuffle.

* Support external EEP scale-down for `data_parallel_external_lb`.
  * The external orchestrator removes target ranks from the external load balancer first.
  * Remaining and removing ranks enter the EEP reconfiguration flow.
  * Removing ranks report shutdown completion after reconfiguration.

* Add per-rank external scale completion reporting.
  * In external LB mode, each old rank reports its own `RECONFIGURE_FINISHED`.
  * This allows each `/scale_elastic_ep` request to return once its local rank has completed reconfiguration, instead of depending on rank 0 only.

* Preserve the existing Ray-managed EEP path.
  * This PR only adds an alternate orchestration path for externally managed DP ranks.

### Usage

External orchestrators trigger scaling by calling the serving API on old ranks:

```bash
POST /scale_elastic_ep
{
  "new_data_parallel_size": 3,
  "drain_timeout": 120
}
```

For scale-up:

1. Call `/scale_elastic_ep` on all old ranks.
2. Launch the new ranks externally.
3. After reconfiguration succeeds, add the new ranks to the external load balancer.

For scale-down:

1. Remove target ranks from the external load balancer.
2. Call `/scale_elastic_ep` on all old ranks.
3. Removed ranks shut down after the EEP transition completes.

## Architecture

```mermaid
flowchart TB
    O[External Orchestrator] -->|POST /scale_elastic_ep| A[Old Rank API Servers]
    O -->|launch / remove ranks| N[New or Removed Rank Processes]
    LB[External Load Balancer] --> A

    A --> C[Temporary External EEP Scale Coordinator]
    C --> E[Existing EngineCores]
    C -. scale-up handshake .-> N
    E <-->|new DP group / TCPStore| N
    E --> W[Workers / ModelExecutor]
```

## Scale-Up Flow

```mermaid
sequenceDiagram
    participant O as External Orchestrator
    participant A as Old Rank API Servers
    participant C as Temporary Scale Coordinator
    participant N as New Rank Processes
    participant E as Existing EngineCores

    O->>A: POST /scale_elastic_ep
    A->>C: publish bootstrap and open temporary handshake
    O->>N: launch new ranks
    N->>C: join through scale-up handshake
    C->>E: reinitialize_distributed
    E->>N: transfer state and form new DP group
    E-->>A: local rank reconfiguration completed
    O->>O: add new ranks to external load balancer
```

## Scale-Down Flow

```mermaid
sequenceDiagram
    participant O as External Orchestrator
    participant LB as External Load Balancer
    participant A as Old Rank API Servers
    participant C as Temporary Scale Coordinator
    participant E as EngineCores

    O->>LB: remove ranks [M, N) from traffic
    O->>A: POST /scale_elastic_ep
    A->>C: coordinate smaller topology
    C->>E: reinitialize remaining and removing ranks
    E->>E: reshuffle experts and switch DP group
    E-->>A: local rank reconfiguration or shutdown completed
```

## Implementation Notes

The main change is concentrated in the API server / client / EngineCore control path.

* `vllm/distributed/elastic_ep/external_elastic_ep.py`
  * Adds the temporary external EEP scale coordinator.
  * Coordinates bootstrap metadata, scale-up handshake, rank notifications, and local rank completion.
  * The coordinator exists only for the duration of one scale operation and is removed after scale-up / scale-down finishes.

* `vllm/v1/engine/core_client.py`
  * Extends `DPAsyncMPClient` to drive external EEP scaling.

* `vllm/v1/engine/core.py`
  * Handles distributed reinitialization requests.
  * Preserves rank-0 notification routing for externally launched scale-up ranks.

* `vllm/v1/engine/utils.py`
  * Creates and retains the Elastic EP coordination TCPStore during startup.
  * Sends runtime coordination metadata through startup handshakes.

* `vllm/distributed/elastic_ep/elastic_state.py`
  * Reuses the existing EEP state machine.
  * Reports per-rank reconfiguration completion in external LB mode.

* `vllm/config/parallel.py`
  * Adds / carries the runtime coordination metadata required by external EEP scaling.

## Compatibility

External EEP scaling requires:

* `enable_elastic_ep=True`
* `data_parallel_external_lb=True`
* `data_parallel_size > 1`

This PR does not change the existing Ray-managed EEP scaling path.

## Test Plan

### Models tested

* Qwen3-30B-A3B

### Test environment

* External load balancer mode
* Multiple DP ranks
* `--enable-expert-parallel`
* `--enable-eplb`
* `--enable-elastic-ep`

### Workflow

1. Start old-rank vLLM online serving instances with external DP LB enabled:

```bash
python -m vllm.entrypoints.openai.api_server \
    --model <model path> \
    --enable-expert-parallel \
    --enable-eplb \
    --enable-elastic-ep \
    --data-parallel-size <old dp size> \
    --data-parallel-rank <rank> \
    --data-parallel-master-ip <master ip> \
    --data-parallel-rpc-port <rpc port> \
    --host 0.0.0.0 \
    --port <api port>
```

2. Trigger external scaling on every old rank. The existing scale helper can be used for external LB as long as it is invoked for each old-rank API server endpoint, preferably concurrently:

```bash
python examples/online_serving/elastic_ep/scale.py \
    --host <old-rank-0-host> \
    --port <old-rank-0-port> \
    --new-dp-size <new dp size>

python examples/online_serving/elastic_ep/scale.py \
    --host <old-rank-1-host> \
    --port <old-rank-1-port> \
    --new-dp-size <new dp size>
```

3. For scale-up, launch the new rank processes externally while the old ranks are waiting for the scale operation to complete.

4. Send requests through the external load balancer after scaling and verify that inference succeeds.

## Test Result

### Test scenarios

| Scenario | Result |
| --- | --- |
| DP 8 -> DP 4 -> DP 3 -> DP 2 | Scale down succeeds and serving requests continue successfully after each topology change. |
| DP 2 -> DP 4 -> DP 8 | Scale up succeeds and serving requests continue successfully after each topology change. |
| DP 4 -> DP 8 -> DP 3 -> DP 8 | Repeated scale-up / scale-down succeeds and serving requests continue successfully after each topology change. |


