### PR TITLE
[Feature] Detect all2all peer fault with fault tolerance backend and prevent corrupted output

### DIFF
--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -260,6 +260,10 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
     All2All communication based on DeepEP Low-Latency kernels.
     """
 
+    _active_buffer: Any = None
+    _mask: torch.Tensor | None = None
+    _last_mask: torch.Tensor | None = None
+
     def __init__(self, cpu_group, tcp_store_group=None):
         super().__init__(cpu_group, tcp_store_group)
 
@@ -303,6 +307,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
             allow_nvlink_for_low_latency_mode=True,
             allow_mnnvl=envs.VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL,
             explicitly_destroy=True,
+            enable_shrink=False,  # TODO: set to True when fault tolerance is supported.
         )
         return kwargs
 
@@ -318,11 +323,42 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         handle: deep_ep.Buffer = self.handle_cache.get_or_create(
             buffer_kwargs, deep_ep.Buffer
         )
+        DeepEPLLAll2AllManager._active_buffer = handle
         return handle
 
     # DeepEP LL uses RDMA so no SMs are used for communication
     def max_sms_used(self) -> int | None:
         return 0
+
+    @property
+    def support_fault_tolerance(self) -> bool:
+        buf = DeepEPLLAll2AllManager._active_buffer
+        return buf is not None and getattr(buf, "enable_shrink", False)
+
+    def query_active_mask(self) -> torch.Tensor:
+        buf = DeepEPLLAll2AllManager._active_buffer
+        assert buf is not None
+        if DeepEPLLAll2AllManager._mask is None:
+            DeepEPLLAll2AllManager._mask = torch.zeros(
+                self.world_size, device="cuda", dtype=torch.int32
+            )
+        buf.low_latency_query_mask_buffer(DeepEPLLAll2AllManager._mask)
+        return DeepEPLLAll2AllManager._mask
+
+    def clean_mask(self) -> None:
+        buf = DeepEPLLAll2AllManager._active_buffer
+        assert buf is not None
+        buf.low_latency_clean_mask_buffer()
+        if DeepEPLLAll2AllManager._last_mask is not None:
+            DeepEPLLAll2AllManager._last_mask.zero_()
+
+    def query_fault(self) -> tuple[torch.Tensor, torch.Tensor]:
+        current = self.query_active_mask()
+        if DeepEPLLAll2AllManager._last_mask is None:
+            DeepEPLLAll2AllManager._last_mask = torch.zeros_like(current)
+        has_fault = (current != DeepEPLLAll2AllManager._last_mask).any()
+        DeepEPLLAll2AllManager._last_mask.copy_(current)
+        return has_fault, current
 
 
 @dataclass
@@ -340,6 +376,8 @@ class NixlEPAll2AllManager(All2AllManagerBase):
 
     _buffer: _NixlEPBufferState | None = None
     _lock = threading.RLock()
+    _full_mask: torch.Tensor | None = None
+    _last_active_mask: torch.Tensor | None = None
 
     def __init__(self, cpu_group, tcp_store_group=None):
         assert tcp_store_group is not None
@@ -501,6 +539,37 @@ class NixlEPAll2AllManager(All2AllManagerBase):
     # NIXL EP uses RDMA so no SMs are used for communication
     def max_sms_used(self) -> int | None:
         return 0
+
+    @property
+    def support_fault_tolerance(self) -> bool:
+        return True
+
+    def query_active_mask(self) -> torch.Tensor:
+        state = NixlEPAll2AllManager._buffer
+        assert state is not None
+        if NixlEPAll2AllManager._full_mask is None:
+            NixlEPAll2AllManager._full_mask = torch.zeros(
+                self.max_num_ep_ranks, device="cuda", dtype=torch.int32
+            )
+        state.buffer.query_mask_buffer(NixlEPAll2AllManager._full_mask)
+        return NixlEPAll2AllManager._full_mask[: state.active_ep_size]
+
+    def clean_mask(self) -> None:
+        state = NixlEPAll2AllManager._buffer
+        assert state is not None
+        state.buffer.clean_mask_buffer()
+        NixlEPAll2AllManager._last_active_mask = None
+
+    def query_fault(self) -> tuple[torch.Tensor, torch.Tensor]:
+        current = self.query_active_mask()
+        last = NixlEPAll2AllManager._last_active_mask
+        if last is None or last.shape != current.shape:
+            NixlEPAll2AllManager._last_active_mask = torch.zeros_like(current)
+            last = NixlEPAll2AllManager._last_active_mask
+        has_fault = (current != last).any()
+        assert last is not None
+        last.copy_(current)
+        return has_fault, current
 
 
 class FlashInferNVLinkTwoSidedManager(All2AllManagerBase):

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -102,6 +102,20 @@ class All2AllManagerBase:
         # - raise a clear error if extra_tensors is not supported.
         raise NotImplementedError
 
+    @property
+    def support_fault_tolerance(self) -> bool:
+        return False
+
+    def query_active_mask(self) -> torch.Tensor:
+        raise NotImplementedError
+
+    def clean_mask(self) -> None:
+        raise NotImplementedError
+
+    def query_fault(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Returns (has_fault scalar, current_active_mask)."""
+        raise NotImplementedError
+
     def set_num_sms(self, num_sms: int):
         pass
 

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -49,7 +49,7 @@ if current_platform.is_cuda_alike():
         )
 
 
-def _get_ep_all2all_manager(eep_stage: bool = False) -> Any:
+def get_ep_all2all_manager(eep_stage: bool = False) -> Any:
     if eep_stage:
         from vllm.distributed.elastic_ep.standby_state import get_standby_ep_group
 
@@ -134,7 +134,7 @@ def maybe_make_prepare_finalize(
                 "Detected DP deployment with no --enable-expert-parallel. "
                 "Falling back to AllGather+ReduceScatter dispatch/combine."
             )
-            all2all_manager = _get_ep_all2all_manager(eep_stage)
+            all2all_manager = get_ep_all2all_manager(eep_stage)
             return make_moe_prepare_and_finalize_naive_dp_ep(
                 is_sequence_parallel=moe.moe_parallel_config.is_sequence_parallel,
                 num_dispatchers=all2all_manager.world_size,
@@ -143,7 +143,7 @@ def maybe_make_prepare_finalize(
         else:
             return make_moe_prepare_and_finalize_no_dp_ep(use_monolithic)
 
-    all2all_manager = _get_ep_all2all_manager(eep_stage)
+    all2all_manager = get_ep_all2all_manager(eep_stage)
 
     prepare_finalize: FusedMoEPrepareAndFinalize | None = None
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -57,6 +57,7 @@ from vllm.logger import init_logger
 from vllm.lora.layers import LoRAMapping, LoRAMappingType
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsCapturer,
 )
@@ -243,6 +244,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         async_output_copy_stream: torch.cuda.Stream,
         vocab_size: int,
         routed_experts: RoutedExpertsTensors | None = None,
+        check_ep_fault: bool = False,
     ):
         self._model_runner_output = model_runner_output
         self._invalid_req_indices = invalid_req_indices
@@ -256,6 +258,8 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         self.vocab_size = vocab_size
         self._logprobs_tensors = logprobs_tensors
         self._routed_experts = routed_experts
+        self._has_fault: torch.Tensor | None = None
+        self._current_mask: torch.Tensor | None = None
 
         # Initiate the copy on a separate stream, but do not synchronize it.
         default_stream = torch.cuda.current_stream()
@@ -274,6 +278,10 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
                 if self._routed_experts is not None
                 else None
             )
+            if check_ep_fault:
+                has_fault, current_mask = get_ep_all2all_manager().query_fault()
+                self._has_fault = has_fault.to("cpu", non_blocking=True)
+                self._current_mask = current_mask
             self.async_copy_ready_event.record()
 
     def get_output(self) -> ModelRunnerOutput:
@@ -309,6 +317,14 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         if self._routed_experts_cpu is not None:
             output.routed_experts = self._routed_experts_cpu.tolists()
         del self._routed_experts
+
+        if self._has_fault is not None and self._has_fault.item():
+            assert self._current_mask is not None
+            raise RuntimeError(
+                "Fault detected in EP all2all communication: "
+                "one or more ranks timed out during dispatch/combine. "
+                f"Mask: {self._current_mask.cpu().tolist()}"
+            )
 
         return output
 
@@ -439,6 +455,10 @@ class GPUModelRunner(
         self.device = device
         self.pin_memory = is_pin_memory_available()
         self.dtype = self.model_config.dtype
+
+        self.check_ep_fault = False
+        if parallel_config.data_parallel_size > 1 and self.model_config.is_moe:
+            self.check_ep_fault = get_ep_all2all_manager().support_fault_tolerance
 
         self.kv_cache_dtype = kv_cache_dtype_str_to_dtype(
             cache_config.cache_dtype, self.model_config
@@ -4574,6 +4594,7 @@ class GPUModelRunner(
                 async_output_copy_stream=self._get_or_create_async_output_copy_stream(),
                 vocab_size=self.input_batch.vocab_size,
                 routed_experts=routed_experts_snapshot,
+                check_ep_fault=self.check_ep_fault,
             )
         with record_function_or_nullcontext(
             "gpu_model_runner: set_async_sampled_token_ids"


### PR DESCRIPTION

## Purpose

Some all2all backends (nixl_ep, deepep_low_latency) support fault-tolerant communication: when a peer rank fails, instead of hanging indefinitely like traditional collectives, the healthy rank sets a mask to exclude the failed rank after a configurable timeout and continues running. However, the ongoing forward pass that triggered the timeout already produced a corrupted token (computed with one rank missing during MoE dispatch/combine). Currently, under the nixl_ep backend, this corrupted token is returned to EngineCore and ultimately to the end user.

This PR prevents corrupted tokens from reaching users by detecting all2all faults at the output boundary. Specifically:

1. **All2AllManagerBase** (`base_device_communicator.py`) gains three new abstract methods — `query_active_mask()`, `clean_mask()`, and `query_fault()` — plus a `support_fault_tolerance` property that backends override to declare FT capability.

2. **DeepEPLLAll2AllManager** and **NixlEPAll2AllManager** (`all2all.py`) implement these methods by querying the kernel's internal mask buffer:
   - `query_active_mask()` returns the current mask tensor (which ranks are alive).
   - `query_fault()` diffs the current mask against the last known mask; returns `(has_fault: bool, current_mask: Tensor)`.
   - `clean_mask()` resets the mask and clears the tracked last-mask state.

3. **AsyncGPUModelRunnerOutput** (`gpu_model_runner.py`) queries `query_fault()` during the async GPU→CPU copy phase (`_start_async_copy`). If `has_fault` is true when `get_output()` is called, a `RuntimeError` is raised — preventing the corrupted token from ever reaching the caller.


**Why now:**

1. **nixl_ep has FT enabled by default.** This means that today, when a rank times out, vLLM silently produces a corrupted token after the kernel timeout and returns it to the user. This PR stops that from happening — the output is intercepted and an exception is raised instead.

2. **Building block for the broader fault tolerance system.** Once corrupted tokens are reliably intercepted, the orchestrator can apply recovery policies (retry for transient network flaps, scale-down for permanent GPU failures) on top of this foundation. This PR is intentionally scoped to a single, reviewable concern: detect → raise.

## Test Plan

DP=4, TP=1, EP enabled with Qwen3-30B-A3B.

**Backends tested:** Both `nixl_ep` and `deepep_low_latency`. (DeepEP LL requires manually enabling shrink mode since it is off by default.)

**Fault injection:** Patch `_run_ar()` in `vllm/v1/worker/dp_utils.py` to inject `time.sleep(600)` on rank 1 **after** the `dist.all_reduce` call at step N. This causes rank 1 to hang immediately before entering all2all expert dispatch. The healthy ranks (0, 2, 3) then hit the all2all kernel timeout during MoE dispatch/combine.

## Test Result

**Baseline (without this PR):** When rank 1 hangs, ranks 0, 2, 3 hit the nixl_ep kernel timeout, which sets the mask and allows the kernel to continue. Any rank that is executing `execute_model` completes the forward pass with a corrupted token and returns it to the client via `sample_tokens`.

**With this PR:** Same fault injection. When rank 1 hangs, the ranks executing `execute_model` hit the nixl_ep kernel timeout and the mask is set. During `AsyncGPUModelRunnerOutput._start_async_copy`, `query_fault()` detects the mask change. When `get_output()` is called, a `RuntimeError` is raised:

> RuntimeError: Fault detected in EP all2all communication: one or more ranks timed out during dispatch/combine. Mask: [0, 1, 0, 0]

The corrupted token is never returned to the client.



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

