### PR TITLE
fix: make FaultInfo.engine_id optional, fix undefined engine_identity…

### DIFF
--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -213,10 +213,8 @@ class CoreEngineProcManager:
                 if exitcode != 0 and not self.manager_stopped.is_set():
                     self.failed_proc_name = proc.name
                 if self.enable_fault_tolerance:
-                    engine_rank = self.processes.index(proc)
                     notify_engine_down(
                         self.engine_down_socket,
-                        engine_id=str(engine_rank + self.start_index),
                         engine_identity=pid_mapping[died_proc.pid],
                     )
                     sentinels.remove(cast(int, sentinel))
@@ -914,11 +912,7 @@ class CoreEngineActorManager:
                     self.failed_proc_name = f"Actor {actor_ref}"
                     unexpected_failure = True
                     if self.enable_fault_tolerance:
-                        engine_rank = self.get_run_refs().index(actor_ref)
-                        notify_engine_down(
-                            self.engine_down_socket,
-                            str(engine_rank + self.start_rank),
-                        )
+                        notify_engine_down(self.engine_down_socket)
                         failed_ref.add(actor_ref)
 
             if unexpected_failure and not self.enable_fault_tolerance:

--- a/vllm/v1/fault_tolerance/client_sentinel.py
+++ b/vllm/v1/fault_tolerance/client_sentinel.py
@@ -456,14 +456,11 @@ class ClientSentinel(BaseSentinel):
                 ):
                     continue
                 if fault_info.type == "EngineDeadError":
-                    engine_identity = next(
-                        k
-                        for k, v in self.engine_identity_to_index.items()
-                        if v == int(fault_info.engine_id)
-                    )
-                    self.killed_engine_identity.append(engine_identity)
+                    self.killed_engine_identity.append(fault_info.engine_identity)
+
                 status_enum = EngineStatusType(fault_info.engine_status)
-                self.engine_status_dict[int(fault_info.engine_id)] = {
+                engine_id = self.engine_identity_to_index[fault_info.engine_identity]
+                self.engine_status_dict[engine_id] = {
                     "status": status_enum.name.lower()
                 }
                 await self._pub_engine_status()

--- a/vllm/v1/fault_tolerance/utils.py
+++ b/vllm/v1/fault_tolerance/utils.py
@@ -21,8 +21,8 @@ FAULT_STATE_PUB_TOPIC = "vllm_fault"
 class FaultInfo(msgspec.Struct):
     type: str
     message: str
-    engine_id: str
     engine_status: EngineStatusType
+    engine_id: str | None = None
     engine_identity: bytes | None = None
     timestamp: str | None = None
     additional_info: dict | None = None
@@ -165,11 +165,11 @@ def make_engine_down_report_socket(vllm_config):
     return zmq_ctx, engine_down_socket
 
 
-def notify_engine_down(engine_down_socket, engine_id, engine_identity=None):
+def notify_engine_down(engine_down_socket, engine_id=None, engine_identity=None):
     fault_info = FaultInfo(
         type="EngineDeadError",
         message="Engine died unexpectedly.",
-        engine_id=str(engine_id),
+        engine_id=str(engine_id) if engine_id is not None else None,
         engine_identity=engine_identity,
         engine_status=EngineStatusType.DEAD,
     )


### PR DESCRIPTION
… bug

- FaultInfo.engine_id: str -> str | None = None, allowing callers (e.g. notify_engine_down) to omit engine_id
- notify_engine_down: don't convert None engine_id to string "None"
- client_sentinel.py: fix undefined variable engine_identity ->
  fault_info.engine_identity in killed_engine_identity.append
- client_sentinel.py: resolve engine_id from engine_identity_to_index fallback when engine_id is not provided in FaultInfo

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

