### PR TITLE
refactor: merge send_engine_registry two recv_multipart into one

### DIFF
--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -167,10 +167,13 @@ class CoreEngineProcManager:
                 self.shutdown()
 
     def recv_engine_identity(self, start_engine_index, local_engine_count):
-        start_engine_bytes = str(start_engine_index).encode("utf-8")
-        local_engine_count_bytes = str(local_engine_count).encode("utf-8")
-        self.engine_down_socket.send_multipart([b"", start_engine_bytes])
-        self.engine_down_socket.send_multipart([b"", local_engine_count_bytes])
+        payload = msgpack.dumps(
+            {
+                "start_engine_index": start_engine_index,
+                "local_engine_count": local_engine_count,
+            }
+        )
+        self.engine_down_socket.send_multipart([b"", payload])
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown engine core processes with configurable timeout."""

--- a/vllm/v1/fault_tolerance/client_sentinel.py
+++ b/vllm/v1/fault_tolerance/client_sentinel.py
@@ -162,25 +162,19 @@ class ClientSentinel(BaseSentinel):
             (
                 sender_identity,
                 empty_frame,
-                start_engine_index_bytes,
+                payload,
             ) = await self.fault_receiver_socket.recv_multipart()
-            start_engine_index = start_engine_index_bytes.decode("utf-8")
+            info = msgpack.loads(payload, strict_map_key=False)
 
-            (
-                sender_identity,
-                empty_frame,
-                node_engine_count_bytes,
-            ) = await self.fault_receiver_socket.recv_multipart()
-            node_engine_count = node_engine_count_bytes.decode("utf-8")
+            start_engine_index = int(info["start_engine_index"])
+            node_engine_count = int(info["local_engine_count"])
+            recv_engine_count += node_engine_count
 
-            assert node_engine_count is not None, "node_engine_count cannot be None"
-            assert start_engine_index is not None, "start_engine_index cannot be None"
-            recv_engine_count += int(node_engine_count)
             send_engine_registry = {
                 key: self.engine_registry[key]
                 for key in range(
-                    int(start_engine_index),
-                    int(start_engine_index) + int(node_engine_count),
+                    start_engine_index,
+                    start_engine_index + node_engine_count,
                 )
             }
             send_engine_registry_byte = msgpack.dumps(
@@ -205,12 +199,14 @@ class ClientSentinel(BaseSentinel):
 
     async def pause(self, ft_request: FaultToleranceRequest):  # type: ignore[override]
         """Expected params: timeout, exclude_engine_index (optional)."""
-        # Pause all engines except ones already marked dead or being excluded.
-        target_engines = []
-        for i, status in self.engine_status_dict.items():
-            for id, new_index in self.engine_identity_to_index:
-                if new_index == i:
-                    target_engines.append(id.to_bytes(2, "little"))
+        exclude_engine_index = ft_request.params.get("exclude_engine_index")
+        # Pause all healthy engines except ones being excluded.
+        target_engines = [
+            self.engine_identities[i - self.start_rank]
+            for i, status in self.engine_status_dict.items()
+            if status["status"] != EngineStatusType.DEAD.name.lower()
+            and (exclude_engine_index is None or i not in exclude_engine_index)
+        ]
         res = await self._execute_cmd_on_engines(ft_request, target_engines)
         if res.success:
             logger.info("vLLM instance is paused and waiting for recovery commands.")

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -116,7 +116,7 @@ class EngineCoreSentinel(BaseSentinel):
                 else EngineStatusType.UNHEALTHY
             )
             msg = FaultInfo.from_exception(
-                engine_exception, self.engine_index, engine_status
+                engine_exception, self.engine_index, engine_status, self.identity
             )
             msg_bytes = msgspec.msgpack.encode(msg)
             self.engine_fault_socket.send_multipart([b"", msg_bytes])


### PR DESCRIPTION
- Sender (recv_engine_identity): pack start_engine_index and local_engine_count into a single msgpack dict instead of two separate send_multipart calls
- Receiver (send_engine_registry): single recv_multipart + msgpack.loads instead of two separate recv_multipart calls

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

