### PR TITLE
refactor: use self.engine_identity instead of self.identity for Fault…

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1311,8 +1311,9 @@ class EngineCoreProc(EngineCore):
                 return
             output = UtilityOutput(call_id)
             # Lazily look-up utility method so that failure will be handled/returned.
-            get_result = lambda: (method := getattr(self, method_name)) and method(
-                *self._convert_msgspec_args(method, args)
+            get_result = lambda: (
+                (method := getattr(self, method_name))
+                and method(*self._convert_msgspec_args(method, args))
             )
             enqueue_output = lambda out: self.output_queue.put_nowait(
                 (client_idx, EngineCoreOutputs(utility_output=out))

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -722,7 +722,7 @@ class MPClient(EngineCoreClient):
         # marks the engine as dead, and shuts down the client.
         def monitor_engine_cores():
             if isinstance(engine_manager, CoreEngineProcManager):
-                engine_manager.monitor_engine_liveness(self.engine_registry)
+                engine_manager.monitor_engine_liveness(self.core_engines)
             else:
                 engine_manager.monitor_engine_liveness()
 

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -202,7 +202,7 @@ class CoreEngineProcManager:
         if self.enable_fault_tolerance:
             pid_mapping = {
                 proc: byte_data
-                for proc, byte_data in zip(pids, engine_identity.values())
+                for proc, byte_data in zip(pids, engine_identity)
             }
         while sentinels and not self.manager_stopped.is_set():
             died_sentinels = connection.wait(sentinels, timeout=1)

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -159,14 +159,14 @@ class CoreEngineProcManager:
                         proc.start()
                 else:
                     proc.start()
-            if not local_client and vllm_config.parallel_config.enable_fault_tolerance:
-                self.recv_engine_identity(start_index, local_engine_count)
+            if vllm_config.parallel_config.enable_fault_tolerance:
+                self.send_engine_range(start_index, local_engine_count)
         finally:
             # Kill other procs if not all are running.
             if self.finished_procs():
                 self.shutdown()
 
-    def recv_engine_identity(self, start_engine_index, local_engine_count):
+    def send_engine_range(self, start_engine_index, local_engine_count):
         payload = msgpack.dumps(
             {
                 "start_engine_index": start_engine_index,
@@ -190,10 +190,10 @@ class CoreEngineProcManager:
 
     def monitor_engine_liveness(self, engine_identity=None, run_headless=False) -> None:
         """Monitor engine core process liveness."""
-        if run_headless and self.enable_fault_tolerance:
+        if self.enable_fault_tolerance:
             engine_identity = msgpack.loads(
                 self.engine_down_socket.recv_multipart()[1], strict_map_key=False
-            )
+            ).values()
 
         sentinel_to_proc = {proc.sentinel: proc for proc in self.processes}
         sentinels = set(sentinel_to_proc.keys())
@@ -201,8 +201,7 @@ class CoreEngineProcManager:
         pid_mapping = {}
         if self.enable_fault_tolerance:
             pid_mapping = {
-                proc: byte_data
-                for proc, byte_data in zip(pids, engine_identity)
+                proc: byte_data for proc, byte_data in zip(pids, engine_identity)
             }
         while sentinels and not self.manager_stopped.is_set():
             died_sentinels = connection.wait(sentinels, timeout=1)

--- a/vllm/v1/fault_tolerance/client_sentinel.py
+++ b/vllm/v1/fault_tolerance/client_sentinel.py
@@ -155,7 +155,7 @@ class ClientSentinel(BaseSentinel):
         asyncio.create_task(self.poll_and_execute_cmd())
 
     async def send_engine_registry(self, dp_size, dp_size_local) -> None:
-        recv_engine_count = dp_size_local
+        recv_engine_count = 0
         while recv_engine_count < dp_size:
             (
                 sender_identity,

--- a/vllm/v1/fault_tolerance/client_sentinel.py
+++ b/vllm/v1/fault_tolerance/client_sentinel.py
@@ -143,8 +143,6 @@ class ClientSentinel(BaseSentinel):
             )
         }
 
-        self.engine_registry = self.core_client.engine_registry
-
         self.engine_identity_to_index = {
             identity: index
             for index, identity in zip(
@@ -171,7 +169,7 @@ class ClientSentinel(BaseSentinel):
             recv_engine_count += node_engine_count
 
             send_engine_registry = {
-                key: self.engine_registry[key]
+                key: self.engine_identities[key]
                 for key in range(
                     start_engine_index,
                     start_engine_index + node_engine_count,
@@ -279,7 +277,6 @@ class ClientSentinel(BaseSentinel):
     def update_config(self, exclude_dp_ranks, original_to_new):
         for engine_index in exclude_dp_ranks:
             self.engine_status_dict.pop(engine_index)
-            self.engine_registry.pop(engine_index)
 
         exclude_set = set(exclude_dp_ranks)
 
@@ -297,10 +294,6 @@ class ClientSentinel(BaseSentinel):
                 del self.engine_status_dict[old_idx]
                 self.engine_status_dict[new_idx] = status_value
 
-            # Migrate engine registry
-            if old_idx in self.engine_registry:
-                self.engine_registry[new_idx] = self.engine_registry.pop(old_idx)
-
             # Update the mapping from engine identifier to index
             for identity, idx in self.engine_identity_to_index.items():
                 if idx == old_idx:
@@ -317,6 +310,12 @@ class ClientSentinel(BaseSentinel):
         self.core_client.core_engines = [
             engine_identity
             for engine_identity in self.core_client.core_engines
+            if engine_identity in self.scaled_down_core_engines_dict
+        ]
+
+        self.engine_identities = [
+            engine_identity
+            for engine_identity in self.engine_identities
             if engine_identity in self.scaled_down_core_engines_dict
         ]
 
@@ -448,7 +447,7 @@ class ClientSentinel(BaseSentinel):
                 # Update engine status
                 if (
                     fault_info.engine_identity
-                    and fault_info.engine_identity not in self.engine_registry.values()
+                    and fault_info.engine_identity not in self.core_client.core_engines
                 ):
                     continue
                 if fault_info.type == "EngineDeadError":

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -56,6 +56,7 @@ class EngineCoreSentinel(BaseSentinel):
             f"DP_{engine_index}",
             sentinel_identity,
         )
+        self.engine_identity = self.engine_index.to_bytes(length=2, byteorder="little")
         self.engine_core = engine_core
         self.data_parallel_size = parallel_config.data_parallel_size
         self.fault_signal_q: queue.Queue[Exception] = queue.Queue()
@@ -116,7 +117,7 @@ class EngineCoreSentinel(BaseSentinel):
                 else EngineStatusType.UNHEALTHY
             )
             msg = FaultInfo.from_exception(
-                engine_exception, self.engine_index, engine_status, self.identity
+                engine_exception, self.engine_index, engine_status, self.engine_identity
             )
             msg_bytes = msgspec.msgpack.encode(msg)
             self.engine_fault_socket.send_multipart([b"", msg_bytes])


### PR DESCRIPTION
…Info

- Add self.engine_identity = engine_index.to_bytes(2, 'little')
- Use self.engine_identity in FaultInfo.from_exception to distinguish engine identity from ZMQ sentinel_identity (self.identity)

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

