### PR TITLE
refactor: sync scale_down config via pub/sub to all API server processes

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1240,10 +1240,57 @@ class AsyncMPClient(MPClient):
         while True:
             try:
                 frames = self.fault_state_sub_socket.recv_multipart()
+                msg = decoder.decode(frames[-1])
                 with self.engine_status_lock:
-                    self.engine_status = decoder.decode(frames[-1])
+                    self.engine_status = msg
+                    if "original_to_new" in msg and "exclude_dp_ranks" in msg:
+                        self._apply_scale_down_config(
+                            msg["exclude_dp_ranks"],
+                            msg["original_to_new"],
+                        )
             except zmq.ZMQError:
                 break
+
+    def _apply_scale_down_config(
+        self, exclude_dp_ranks: list[int], original_to_new: dict[int, int]
+    ):
+        """Apply scale_down config updates from ClientSentinel pub message.
+
+        Mirrors ClientSentinel.update_config() operations on self.core_client,
+        adapted for when self is the core_client (other API server processes).
+        """
+        exclude_set = set(exclude_dp_ranks)
+        old_to_new = {int(k): v for k, v in original_to_new.items()}
+
+        # 1. Filter core_engines: keep identities whose rank is not excluded.
+        self.core_engines = [
+            identity
+            for rank, identity in zip(self.engine_ranks_managed, self.core_engines)
+            if rank not in exclude_set
+        ]
+
+        # 2. Reset engine_ranks_managed to contiguous range [0, new_dp_size).
+        new_dp_size = len(old_to_new)
+        self.engine_ranks_managed = list(range(new_dp_size))
+
+        # 3. Update data_parallel_size.
+        self.vllm_config.parallel_config.data_parallel_size = new_dp_size
+
+        # 4. Remove excluded engines from lb_engines by local index (reverse sorted).
+        if hasattr(self, "lb_engines"):
+            dp_rank = self.vllm_config.parallel_config.data_parallel_rank
+            for dead_engine in sorted(exclude_dp_ranks, reverse=True):
+                local_rank = dead_engine - dp_rank
+                if 0 <= local_rank < len(self.lb_engines):
+                    del self.lb_engines[local_rank]
+
+        # 5. Notify DPCoordinator of the scale down (only from client_index=0).
+        if self.client_index == 0:
+            scale_down_marker = msgspec.msgpack.encode(
+                ("SCALE_ELASTIC_EP", new_dp_size)
+            )
+            if self.resources.first_req_send_socket:
+                self.resources.first_req_send_socket.send(scale_down_marker)
 
     async def fault_reporter(self):
         with self.engine_status_lock:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -37,6 +37,7 @@ from vllm.v1.engine import (
     EngineCoreOutputs,
     EngineCoreRequest,
     EngineCoreRequestType,
+    EngineStatusType,
     PauseMode,
     ReconfigureDistributedRequest,
     ReconfigureRankType,
@@ -1230,6 +1231,19 @@ class AsyncMPClient(MPClient):
     async def handle_fault(
         self, ft_request: FaultToleranceRequest
     ) -> FaultToleranceResult:
+        # Reject fault tolerance instructions if any engine is not healthy.
+        healthy_engines = [
+            e
+            for e in self.engine_status["engines"]  # type: ignore[attr-defined]
+            if e["status"] == EngineStatusType.HEALTHY.name.lower()
+        ]
+        if healthy_engines:
+            return FaultToleranceResult(
+                request_id=ft_request.request_id,
+                success=False,
+                reason=f"Some Engines are still hung: {healthy_engines}",
+            )
+
         res = await self._call_utility_async(
             ft_request.instruction, ft_request, engine=b"client_sentinel"
         )
@@ -1242,12 +1256,27 @@ class AsyncMPClient(MPClient):
                 frames = self.fault_state_sub_socket.recv_multipart()
                 msg = decoder.decode(frames[-1])
                 with self.engine_status_lock:
-                    self.engine_status = msg
+                    self.engine_status = {
+                        "total_engines": msg["total_engines"],
+                        "engines": msg["engines"],
+                    }
                     if "original_to_new" in msg and "exclude_dp_ranks" in msg:
-                        self._apply_scale_down_config(
-                            msg["exclude_dp_ranks"],
-                            msg["original_to_new"],
+                        loop = (
+                            self.resources.output_queue_task.get_loop()
+                            if self.resources.output_queue_task
+                            else None
                         )
+                        if loop and loop.is_running():
+                            loop.call_soon_threadsafe(
+                                self._apply_scale_down_config,
+                                msg["exclude_dp_ranks"],
+                                msg["original_to_new"],
+                            )
+                        else:
+                            self._apply_scale_down_config(
+                                msg["exclude_dp_ranks"],
+                                msg["original_to_new"],
+                            )
             except zmq.ZMQError:
                 break
 
@@ -1290,7 +1319,9 @@ class AsyncMPClient(MPClient):
                 ("SCALE_ELASTIC_EP", new_dp_size)
             )
             if self.resources.first_req_send_socket:
-                self.resources.first_req_send_socket.send(scale_down_marker)
+                zmq.Socket.shadow(self.resources.first_req_send_socket).send(
+                    scale_down_marker
+                )
 
     async def fault_reporter(self):
         with self.engine_status_lock:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1232,16 +1232,16 @@ class AsyncMPClient(MPClient):
         self, ft_request: FaultToleranceRequest
     ) -> FaultToleranceResult:
         # Reject fault tolerance instructions if any engine is not healthy.
-        healthy_engines = [
+        hung_engines = [
             e
             for e in self.engine_status["engines"]  # type: ignore[attr-defined]
             if e["status"] == EngineStatusType.HEALTHY.name.lower()
         ]
-        if healthy_engines:
+        if hung_engines:
             return FaultToleranceResult(
                 request_id=ft_request.request_id,
                 success=False,
-                reason=f"Some Engines are still hung: {healthy_engines}",
+                reason=f"Some Engines are still hung: {hung_engines}",
             )
 
         res = await self._call_utility_async(
@@ -1260,7 +1260,7 @@ class AsyncMPClient(MPClient):
                         "total_engines": msg["total_engines"],
                         "engines": msg["engines"],
                     }
-                    if "original_to_new" in msg and "exclude_dp_ranks" in msg:
+                    if msg["type"] == "scale_down":
                         loop = (
                             self.resources.output_queue_task.get_loop()
                             if self.resources.output_queue_task
@@ -1297,6 +1297,8 @@ class AsyncMPClient(MPClient):
             for rank, identity in zip(self.engine_ranks_managed, self.core_engines)
             if rank not in exclude_set
         ]
+        if self.core_engines:
+            self.core_engine = self.core_engines[0]
 
         # 2. Reset engine_ranks_managed to contiguous range [0, new_dp_size).
         new_dp_size = len(old_to_new)

--- a/vllm/v1/fault_tolerance/client_sentinel.py
+++ b/vllm/v1/fault_tolerance/client_sentinel.py
@@ -341,6 +341,7 @@ class ClientSentinel(BaseSentinel):
                     EngineStatusType.HEALTHY.name.lower()
                 )
             await self._pub_engine_status(
+                type="scale_down",
                 exclude_dp_ranks=exclude_dp_ranks,
                 original_to_new=original_to_new,
             )

--- a/vllm/v1/fault_tolerance/client_sentinel.py
+++ b/vllm/v1/fault_tolerance/client_sentinel.py
@@ -290,32 +290,11 @@ class ClientSentinel(BaseSentinel):
             if old_idx in idx_to_identity:
                 self.engine_identity_to_index[idx_to_identity[old_idx]] = new_idx
 
-        self.core_client.core_engines = [
-            identity
-            for identity in self.core_client.core_engines
-            if identity in self.engine_identity_to_index
-        ]
-
         self.engine_identities = [
             identity
             for identity in self.engine_identities
             if identity in self.engine_identity_to_index
         ]
-
-        new_dp_size = len(original_to_new)
-        self.core_client.engine_ranks_managed = list(range(new_dp_size))
-        self.core_client.vllm_config.parallel_config.data_parallel_size = new_dp_size
-
-        scale_down_marker = msgspec.msgpack.encode(("SCALE_ELASTIC_EP", new_dp_size))
-        if self.core_client.resources.first_req_send_socket:
-            self.core_client.resources.first_req_send_socket.send(scale_down_marker)
-
-        if hasattr(self.core_client, "lb_engines"):
-            dp_rank = self.core_client.vllm_config.parallel_config.data_parallel_rank
-            for dead_engine in sorted(exclude_dp_ranks, reverse=True):
-                local_rank = dead_engine - dp_rank
-                if 0 <= local_rank < len(self.core_client.lb_engines):
-                    del self.core_client.lb_engines[local_rank]
 
     async def scale_down(
         self, ft_request: FaultToleranceRequest
@@ -361,12 +340,15 @@ class ClientSentinel(BaseSentinel):
                 self.engine_status_dict[i]["status"] = (
                     EngineStatusType.HEALTHY.name.lower()
                 )
-            await self._pub_engine_status()
+            await self._pub_engine_status(
+                exclude_dp_ranks=exclude_dp_ranks,
+                original_to_new=original_to_new,
+            )
             self.is_faulted.clear()
 
         return res
 
-    async def _pub_engine_status(self):
+    async def _pub_engine_status(self, **extra_fields):
         engine_status = self.engine_status_dict.copy()
         pub_msg = {
             "total_engines": len(engine_status),
@@ -374,6 +356,7 @@ class ClientSentinel(BaseSentinel):
                 {"id": i, "status": status["status"]}
                 for i, status in engine_status.items()
             ],
+            **extra_fields,
         }
         topic = FAULT_STATE_PUB_TOPIC.encode()
         await self.fault_state_pub_socket.send_multipart(

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -3,6 +3,7 @@
 import argparse
 import contextlib
 import multiprocessing
+import threading
 import time
 import weakref
 from collections.abc import Callable, Sequence
@@ -253,8 +254,6 @@ def wait_for_completion_or_failure(
         coordinator: The coordinator for data parallel.
     """
 
-    from vllm.v1.engine.utils import CoreEngineActorManager, CoreEngineProcManager
-
     try:
         logger.info("Waiting for API servers to complete ...")
         # Create a mapping of sentinels to their corresponding processes
@@ -266,33 +265,40 @@ def wait_for_completion_or_failure(
         if coordinator:
             sentinel_to_proc[coordinator.proc.sentinel] = coordinator.proc
 
-        actor_run_refs = []
-        if isinstance(engine_manager, CoreEngineProcManager):
-            for proc in engine_manager.processes:
-                sentinel_to_proc[proc.sentinel] = proc
-        elif isinstance(engine_manager, CoreEngineActorManager):
-            actor_run_refs = engine_manager.get_run_refs()
+        if engine_manager:
+            core_shutdown_recv, core_shutdown_send = connection.Pipe(duplex=False)
+
+            def monitor_engines():
+                try:
+                    engine_manager.monitor_engine_liveness()
+                finally:
+                    core_shutdown_send.close()
+                    core_shutdown_recv.close()
+
+            # start monitor for engine liveness
+            threading.Thread(target=monitor_engines, daemon=True).start()
+            sentinel_to_proc[core_shutdown_recv] = None  # type: ignore[assignment]
 
         # Check if any process terminates
-        while sentinel_to_proc or actor_run_refs:
-            # Wait for any process to terminate
-            ready_sentinels: list[Any] = connection.wait(sentinel_to_proc, timeout=5)
+        while sentinel_to_proc:
+            # Wait for any process to terminate (or engine shutdown signal)
+            ready_sentinels: list[Any] = connection.wait(sentinel_to_proc)
 
             # Process any terminated processes
             for sentinel in ready_sentinels:
                 proc = sentinel_to_proc.pop(sentinel)
 
                 # Check if process exited with error
-                if proc.exitcode != 0:
+                if proc is not None and proc.exitcode != 0:
                     raise RuntimeError(
                         f"Process {proc.name} (PID: {proc.pid}) "
                         f"died with exit code {proc.exitcode}"
                     )
-
-            if actor_run_refs:
-                import ray
-
-                _, actor_run_refs = ray.wait(actor_run_refs, timeout=5)
+                if engine_manager and engine_manager.failed_proc_name is not None:
+                    raise RuntimeError(
+                        f"Engine core process {engine_manager.failed_proc_name} "
+                        "died unexpectedly."
+                    )
 
     except KeyboardInterrupt:
         logger.info("Received KeyboardInterrupt, shutting down API servers...")


### PR DESCRIPTION
Move core_client updates out of ClientSentinel.update_config() and into _apply_scale_down_config() in AsyncMPClient, triggered by the _pub_engine_status() broadcast. This ensures all API server processes (client_index 0..N) consistently update core_engines, engine_ranks_managed, data_parallel_size, and lb_engines on scale_down.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

