### PR TITLE
fix: drain stale executor responses after health check in fault_toler…

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1260,7 +1260,7 @@ class AsyncMPClient(MPClient):
                         "total_engines": msg["total_engines"],
                         "engines": msg["engines"],
                     }
-                    if msg["type"] == "scale_down":
+                    if "type" in msg and msg["type"] == "scale_down":
                         loop = (
                             self.resources.output_queue_task.get_loop()
                             if self.resources.output_queue_task

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -434,6 +434,24 @@ class EngineCoreSentinel(BaseSentinel):
         logger.info("Drained %s responses from engine batch_queue.", num_stale_futures)
 
 
+def drain_stale_responses(executor, num_stale):
+    """Drain stale futures and pending responses from the executor's
+    message queues before issuing a new collective_rpc."""
+    if not executor.response_mqs:
+        return
+    logger.info("[FT] Draining %d stale response(s) from response queue", num_stale)
+    if executor.kv_output_aggregator is not None:
+        mqs = executor.response_mqs
+    else:
+        mqs = (executor.response_mqs[executor.output_rank],)
+    for mq in mqs:
+        for _ in range(num_stale):
+            try:
+                mq.dequeue(10)
+            except Exception:
+                break
+
+
 def fault_tolerant_wrapper(busy_loop_func: Callable):
     """
     Wrap the busy loop function to perform fault tolerance.
@@ -459,6 +477,7 @@ def fault_tolerant_wrapper(busy_loop_func: Callable):
                         "[BusyLoopWrapper] EngineCore busy loop raised a %s exception.",
                         type(original_exc).__name__,
                     )
+                    check_responsive_cnt = 0
                     while (
                         not self.engine_core_sentinel.check_worker_responsive()
                         and time.monotonic() < deadline
@@ -466,11 +485,13 @@ def fault_tolerant_wrapper(busy_loop_func: Callable):
                         logger.warning(
                             "[BusyLoopWrapper] Worker is not responsive. Checking..."
                         )
+                        check_responsive_cnt += 1
                         time.sleep(1)
                     logger.warning(
                         "[BusyLoopWrapper] Engine loop suspended. "
                         "Wait for fault tolerance instructions."
                     )
+                    drain_stale_responses(self.model_executor, check_responsive_cnt)
                     self.engine_core_sentinel.drain_engine_responses()
 
                     self.engine_core_sentinel.fault_signal_q.put(original_exc)

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -401,6 +401,30 @@ class EngineCoreSentinel(BaseSentinel):
             )
             raise SystemExit from err
 
+    def drain_stale_executor_responses(self, executor, num_stale, timeout):
+        """Drain stale futures and pending responses from the executor's
+        message queues before issuing a new collective_rpc."""
+        deadline = (
+            time.monotonic() + self.engine_core_sentinel.engine_recovery_timeout_sec
+        )
+        if not executor.response_mqs:
+            return
+        logger.info("[FT] Draining %d stale response(s) from response queue", num_stale)
+        if executor.kv_output_aggregator is not None:
+            mqs = executor.response_mqs
+        else:
+            mqs = (executor.response_mqs[executor.output_rank],)
+        for mq in mqs:
+            for _ in range(num_stale):
+                try:
+                    mq.dequeue(deadline - time.monotonic())
+                except TimeoutError as err:
+                    raise RuntimeError(
+                        "Timed out while draining stale responses from executor. "
+                    ) from err
+                except Exception:
+                    break
+
     def shutdown_engine_core(
         self, ft_request: FaultToleranceRequest
     ) -> FaultToleranceResult:
@@ -434,24 +458,6 @@ class EngineCoreSentinel(BaseSentinel):
         logger.info("Drained %s responses from engine batch_queue.", num_stale_futures)
 
 
-def drain_stale_responses(executor, num_stale):
-    """Drain stale futures and pending responses from the executor's
-    message queues before issuing a new collective_rpc."""
-    if not executor.response_mqs:
-        return
-    logger.info("[FT] Draining %d stale response(s) from response queue", num_stale)
-    if executor.kv_output_aggregator is not None:
-        mqs = executor.response_mqs
-    else:
-        mqs = (executor.response_mqs[executor.output_rank],)
-    for mq in mqs:
-        for _ in range(num_stale):
-            try:
-                mq.dequeue(10)
-            except Exception:
-                break
-
-
 def fault_tolerant_wrapper(busy_loop_func: Callable):
     """
     Wrap the busy loop function to perform fault tolerance.
@@ -477,7 +483,7 @@ def fault_tolerant_wrapper(busy_loop_func: Callable):
                         "[BusyLoopWrapper] EngineCore busy loop raised a %s exception.",
                         type(original_exc).__name__,
                     )
-                    check_responsive_cnt = 0
+                    check_stale_cnt = 0
                     while (
                         not self.engine_core_sentinel.check_worker_responsive()
                         and time.monotonic() < deadline
@@ -485,13 +491,17 @@ def fault_tolerant_wrapper(busy_loop_func: Callable):
                         logger.warning(
                             "[BusyLoopWrapper] Worker is not responsive. Checking..."
                         )
-                        check_responsive_cnt += 1
+                        check_stale_cnt += 1
                         time.sleep(1)
                     logger.warning(
                         "[BusyLoopWrapper] Engine loop suspended. "
                         "Wait for fault tolerance instructions."
                     )
-                    drain_stale_responses(self.model_executor, check_responsive_cnt)
+                    self.engine_core_sentinel.drain_stale_executor_responses(
+                        self.model_executor,
+                        check_stale_cnt,
+                        deadline - time.monotonic(),
+                    )
                     self.engine_core_sentinel.drain_engine_responses()
 
                     self.engine_core_sentinel.fault_signal_q.put(original_exc)


### PR DESCRIPTION
…ant_wrapper

Add drain_stale_responses() to clear stale futures from executor response MQs based on health check retry count. This prevents stale responses from interfering with collective_rpc during retry.


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

