### PR TITLE
unify param name for nixl and deepep

### DIFF
--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -260,7 +260,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
     All2All communication based on DeepEP Low-Latency kernels.
     """
 
-    _active_buffer: Any = None
+    _buffer: Any = None
     _mask: torch.Tensor | None = None
     _last_mask: torch.Tensor | None = None
 
@@ -324,7 +324,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         handle: deep_ep.Buffer = self.handle_cache.get_or_create(
             buffer_kwargs, deep_ep.Buffer
         )
-        DeepEPLLAll2AllManager._active_buffer = handle
+        DeepEPLLAll2AllManager._buffer = handle
         return handle
 
     # DeepEP LL uses RDMA so no SMs are used for communication
@@ -332,7 +332,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         return 0
 
     def query_active_mask(self) -> torch.Tensor:
-        buf = DeepEPLLAll2AllManager._active_buffer
+        buf = DeepEPLLAll2AllManager._buffer
         assert buf is not None
         if DeepEPLLAll2AllManager._mask is None:
             DeepEPLLAll2AllManager._mask = torch.zeros(
@@ -342,7 +342,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         return DeepEPLLAll2AllManager._mask
 
     def clean_buffers(self) -> None:
-        buf = DeepEPLLAll2AllManager._active_buffer
+        buf = DeepEPLLAll2AllManager._buffer
         if buf is None:
             return
         buf.get_local_buffer_tensor(dtype=torch.int8, use_rdma_buffer=True).zero_()
@@ -376,8 +376,8 @@ class NixlEPAll2AllManager(All2AllManagerBase):
 
     _buffer: _NixlEPBufferState | None = None
     _lock = threading.RLock()
-    _full_mask: torch.Tensor | None = None
-    _last_active_mask: torch.Tensor | None = None
+    _mask: torch.Tensor | None = None
+    _last_mask: torch.Tensor | None = None
 
     def __init__(self, cpu_group, tcp_store_group=None):
         assert tcp_store_group is not None
@@ -544,12 +544,12 @@ class NixlEPAll2AllManager(All2AllManagerBase):
     def query_active_mask(self) -> torch.Tensor:
         state = NixlEPAll2AllManager._buffer
         assert state is not None
-        if NixlEPAll2AllManager._full_mask is None:
-            NixlEPAll2AllManager._full_mask = torch.zeros(
+        if NixlEPAll2AllManager._mask is None:
+            NixlEPAll2AllManager._mask = torch.zeros(
                 self.max_num_ep_ranks, device="cuda", dtype=torch.int32
             )
-        state.buffer.query_mask_buffer(NixlEPAll2AllManager._full_mask)
-        return NixlEPAll2AllManager._full_mask[: state.active_ep_size]
+        state.buffer.query_mask_buffer(NixlEPAll2AllManager._mask)
+        return NixlEPAll2AllManager._mask[: state.active_ep_size]
 
     def clean_buffers(self) -> None:
         if NixlEPAll2AllManager._buffer is None:
@@ -559,14 +559,14 @@ class NixlEPAll2AllManager(All2AllManagerBase):
         torch.accelerator.synchronize()
         buf.clean_mask_buffer()
         torch.accelerator.synchronize()
-        NixlEPAll2AllManager._last_active_mask = None
+        NixlEPAll2AllManager._last_mask = None
 
     def query_fault(self) -> tuple[torch.Tensor, torch.Tensor]:
         current = self.query_active_mask()
-        last = NixlEPAll2AllManager._last_active_mask
+        last = NixlEPAll2AllManager._last_mask
         if last is None or last.shape != current.shape:
-            NixlEPAll2AllManager._last_active_mask = torch.zeros_like(current)
-            last = NixlEPAll2AllManager._last_active_mask
+            NixlEPAll2AllManager._last_mask = torch.zeros_like(current)
+            last = NixlEPAll2AllManager._last_mask
         has_fault = (current != last).any()
         assert last is not None
         last.copy_(current)

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -904,7 +904,11 @@ class WorkerProc:
         converted to a FAILURE response.
         """
         if isinstance(output, AsyncModelRunnerOutput):
-            output = output.get_output()
+            try:
+                output = output.get_output()
+            except Exception as e:
+                logger.exception("Error getting async model runner output")
+                output = e
 
         if isinstance(output, Exception):
             result = (WorkerProc.ResponseStatus.FAILURE, str(output))


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Unify the parameter names in DeepEPLL and Nixl-EP. Add implementations for exception handling in multiproc_executor.
## Test Plan
Tested with DeepEPLL backend(graph mode). Send requests to all ranks. Inject errors by letting rank 1 sleep 600 s at step 500. 
## Test Result

Rank 0,2,3 raised error in EngineCore stating the found of mask changing. Rank 1 also exit automatically.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

