### PR TITLE
unify param name for nixl and deepep and destroy old cpu_group in retry

### DIFF
--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -262,7 +262,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
     All2All communication based on DeepEP Low-Latency kernels.
     """
 
-    _active_buffer: Any = None
+    _buffer: Any = None
     _mask: torch.Tensor | None = None
     _last_mask: torch.Tensor | None = None
 
@@ -328,7 +328,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         handle: deep_ep.Buffer = self.handle_cache.get_or_create(
             buffer_kwargs, deep_ep.Buffer
         )
-        DeepEPLLAll2AllManager._active_buffer = handle
+        DeepEPLLAll2AllManager._buffer = handle
         return handle
 
     # DeepEP LL uses RDMA so no SMs are used for communication
@@ -336,7 +336,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         return 0
 
     def query_active_mask(self) -> torch.Tensor:
-        buf = DeepEPLLAll2AllManager._active_buffer
+        buf = DeepEPLLAll2AllManager._buffer
         assert buf is not None
         if DeepEPLLAll2AllManager._mask is None:
             DeepEPLLAll2AllManager._mask = torch.zeros(
@@ -346,7 +346,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         return DeepEPLLAll2AllManager._mask
 
     def clean_buffers(self) -> None:
-        buf = DeepEPLLAll2AllManager._active_buffer
+        buf = DeepEPLLAll2AllManager._buffer
         if buf is None:
             return
         buf.get_local_buffer_tensor(dtype=torch.int8, use_rdma_buffer=True).zero_()
@@ -379,8 +379,8 @@ class NixlEPAll2AllManager(All2AllManagerBase):
 
     _buffer: _NixlEPBufferState | None = None
     _lock = threading.RLock()
-    _full_mask: torch.Tensor | None = None
-    _last_active_mask: torch.Tensor | None = None
+    _mask: torch.Tensor | None = None
+    _last_mask: torch.Tensor | None = None
 
     def __init__(self, cpu_group, tcp_store_group=None):
         if tcp_store_group is None:
@@ -550,14 +550,14 @@ class NixlEPAll2AllManager(All2AllManagerBase):
         return 0
 
     def query_active_mask(self) -> torch.Tensor:
-        assert NixlEPAll2AllManager._buffer is not None
         state = NixlEPAll2AllManager._buffer
-        if NixlEPAll2AllManager._full_mask is None:
-            NixlEPAll2AllManager._full_mask = torch.zeros(
+        assert state is not None
+        if NixlEPAll2AllManager._mask is None:
+            NixlEPAll2AllManager._mask = torch.zeros(
                 self.max_num_ep_ranks, device="cuda", dtype=torch.int32
             )
-        state.buffer.query_mask_buffer(NixlEPAll2AllManager._full_mask)
-        return NixlEPAll2AllManager._full_mask[: state.active_ep_size]
+        state.buffer.query_mask_buffer(NixlEPAll2AllManager._mask)
+        return NixlEPAll2AllManager._mask[: state.active_ep_size]
 
     def clean_buffers(self) -> None:
         if NixlEPAll2AllManager._buffer is None:
@@ -567,14 +567,14 @@ class NixlEPAll2AllManager(All2AllManagerBase):
         torch.accelerator.synchronize()
         state.buffer.clean_mask_buffer()
         torch.accelerator.synchronize()
-        NixlEPAll2AllManager._last_active_mask = None
+        NixlEPAll2AllManager._last_mask = None
 
     def query_fault(self) -> tuple[torch.Tensor, torch.Tensor]:
         current = self.query_active_mask()
-        last = NixlEPAll2AllManager._last_active_mask
+        last = NixlEPAll2AllManager._last_mask
         if last is None or last.shape != current.shape:
-            NixlEPAll2AllManager._last_active_mask = torch.zeros_like(current)
-            last = NixlEPAll2AllManager._last_active_mask
+            NixlEPAll2AllManager._last_mask = torch.zeros_like(current)
+            last = NixlEPAll2AllManager._last_mask
         has_fault = (current != last).any()
         assert last is not None
         last.copy_(current)

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -932,6 +932,7 @@ class WorkerProc:
             try:
                 output = output.get_output()
             except Exception as e:
+                logger.exception("Error getting async model runner output")
                 output = e
 
         if isinstance(output, Exception):

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -8,6 +8,7 @@ from vllm.config import set_current_vllm_config
 from vllm.distributed import (
     get_dp_group,
     get_ep_group,
+    stateless_destroy_torch_distributed_process_group,
     stateless_init_torch_distributed_process_group,
 )
 from vllm.logger import init_logger
@@ -50,6 +51,8 @@ class WorkerSentinel:
         params = ft_request.params
         self._clean_worker_state()
         if self.dp_size > 1:
+            old_cpu_group = get_dp_group().cpu_group
+            stateless_destroy_torch_distributed_process_group(old_cpu_group)
             port = params["new_stateless_dp_group_port"]
             get_dp_group().cpu_group = stateless_init_torch_distributed_process_group(
                 self.data_parallel_master_ip,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

## Test Plan

**Model**: Qwen3-30B-A3B (MoE, 128 experts)
**Configuration**: DP=4, TP=1, EP=4, `deepep_low_latency` backend

### Launching the cluster

Each DP rank runs as a separate `vllm serve` process. The command below shows rank 0 -- launch one such process per GPU, incrementing `CUDA_VISIBLE_DEVICES`, `--data-parallel-rank`, and `--port` for each rank:

```bash
CUDA_VISIBLE_DEVICES=0 python -m vllm.entrypoints.cli.main serve \
    Qwen/Qwen3-30B-A3B \
    --data-parallel-size 4 \
    --data-parallel-size-local 1 \
    --data-parallel-rank 0 \
    --port 8100 \
    --enable-expert-parallel \
    --all2all-backend deepep_low_latency \
    --gpu-memory-utilization 0.5 \
    --max-model-len 1024 \
    --trust-remote-code \
    --cpu-distributed-timeout-seconds 3 \
    --enable-fault-tolerance \
    --fault-tolerance-config '{"engine_recovery_timeout_sec": 500}'
```

### Simulating faults

To simulate a transient device-side failure, inject a `RuntimeError` in the DP allreduce path (`_run_ar` in `vllm/v1/worker/dp_utils.py`). The patch adds a step counter and raises an exception at specific steps (250 and 5000) on a target rank (rank 1), **after** the allreduce completes:

```python
# After dist.all_reduce(tensor, group=group):
if (step_count in [250, 5000] and dp_rank == 1):
    raise RuntimeError("FAULT INJECTION: exception after allreduce")
```

### Sending inference requests

```bash
# Send a chat completion request to rank 0 (repeat for each rank's port: 8100, 8101, ...):
curl -s http://localhost:8100/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "Qwen/Qwen3-30B-A3B", "messages": [{"role": "user", "content": "Hello"}], "max_tokens": 64}'
```

### Querying FT status and issuing recovery

```bash
# Query engine status (repeat for each rank's port):
curl -s http://localhost:8100/fault_tolerance/status

# Issue retry to all ranks after all become unhealthy:
curl -s -X POST http://localhost:8100/fault_tolerance/apply \
  -H "Content-Type: application/json" \
  -d '{"instruction": "retry", "params": {"timeout": 120}}'
```

## Test Results

Tested with DP=4, EP=4, `deepep_low_latency` backend. Faults were injected at step 250 and step 5000 on DP rank 1. Both fault-recovery cycles completed successfully.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

