### PR TITLE
refactor: extract validate_ft_request from handle_fault to ft/utils.py

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -338,7 +338,6 @@ class GroupCoordinator:
         gloo_timeout_timedelta: timedelta | None = None
         if gloo_timeout_seconds is not None:
             gloo_timeout_timedelta = timedelta(seconds=gloo_timeout_seconds)
-        self.group_type = "normal"
         for ranks in group_ranks:
             device_group = torch.distributed.new_group(
                 ranks, backend=torch_distributed_backend
@@ -1072,10 +1071,7 @@ class GroupCoordinator:
 
     def destroy_cpu_group(self):
         if hasattr(self, "cpu_group"):
-            if self.group_type == "normal":
-                torch.distributed.destroy_process_group(self.cpu_group)
-            else:
-                stateless_destroy_torch_distributed_process_group(self.cpu_group)
+            stateless_destroy_torch_distributed_process_group(self.cpu_group)
             del self.cpu_group
 
     def prepare_communication_buffer_for_model(self, model: torch.nn.Module):

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -37,7 +37,6 @@ from vllm.v1.engine import (
     EngineCoreOutputs,
     EngineCoreRequest,
     EngineCoreRequestType,
-    EngineStatusType,
     PauseMode,
     ReconfigureDistributedRequest,
     ReconfigureRankType,
@@ -59,6 +58,7 @@ from vllm.v1.fault_tolerance.utils import (
     FaultToleranceRequest,
     FaultToleranceResult,
     FaultToleranceZmqAddresses,
+    validate_ft_request,
 )
 from vllm.v1.pool.late_interaction import get_late_interaction_engine_index
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder, bytestr
@@ -1231,18 +1231,14 @@ class AsyncMPClient(MPClient):
     async def handle_fault(
         self, ft_request: FaultToleranceRequest
     ) -> FaultToleranceResult:
-        # Reject fault tolerance instructions if any engine is not healthy.
-        hung_engines = [
-            e
-            for e in self.engine_status["engines"]  # type: ignore[attr-defined]
-            if e["status"] == EngineStatusType.HEALTHY.name.lower()
-        ]
-        if hung_engines:
-            return FaultToleranceResult(
-                request_id=ft_request.request_id,
-                success=False,
-                reason=f"Some Engines are still hung: {hung_engines}",
-            )
+        # Validate engine status according to instruction semantics.
+        if rejection := validate_ft_request(
+            engines=self.engine_status["engines"],  # type: ignore[attr-defined, arg-type]
+            request_id=ft_request.request_id,
+            instruction=ft_request.instruction,
+            exclude_dp_ranks=ft_request.params.get("exclude_dp_ranks"),
+        ):
+            return rejection
 
         res = await self._call_utility_async(
             ft_request.instruction, ft_request, engine=b"client_sentinel"

--- a/vllm/v1/fault_tolerance/utils.py
+++ b/vllm/v1/fault_tolerance/utils.py
@@ -148,6 +148,72 @@ class FaultToleranceZmqAddresses:
         )
 
 
+def validate_ft_request(
+    engines: list[dict[str, object]],
+    request_id: str,
+    instruction: str,
+    exclude_dp_ranks: Any = None,
+) -> FaultToleranceResult | None:
+    """Validate engine status before forwarding a fault tolerance instruction.
+
+    Returns None if validation passes (caller should proceed to execute),
+    or a FaultToleranceResult with success=False if validation fails
+    (caller should return it immediately).
+
+    Validation rules:
+    - **pause**: Always passes — pause itself transitions healthy engines
+      to paused/unhealthy, so rejecting on healthy would create a deadlock.
+    - **retry**: Rejects if any engine is still healthy. After pause, all
+      engines should be paused/unhealthy; a healthy engine at this stage
+      indicates it may have hung during pause, so retry cannot safely proceed.
+    - **scale_down**: Only checks retained engines (those NOT in
+      exclude_dp_ranks). Excluded ranks are being removed and their
+      hung/healthy state is irrelevant to the scale-down operation.
+    - Unknown instructions are passed through without validation.
+    """
+    exclude_set: set[int] = set()
+    if exclude_dp_ranks is not None:
+        exclude_set = set(exclude_dp_ranks)
+
+    if instruction == "pause":
+        # No pre-condition: pause is the first step that puts engines
+        # into paused/unhealthy state.
+        return None
+
+    healthy_engines = [
+        e for e in engines if e["status"] == EngineStatusType.HEALTHY.name.lower()
+    ]
+
+    if instruction == "retry":
+        if healthy_engines:
+            return FaultToleranceResult(
+                request_id=request_id,
+                success=False,
+                reason=(
+                    "Some engines are still healthy — may have hung during "
+                    f"pause: {healthy_engines}"
+                ),
+            )
+        return None
+
+    if instruction == "scale_down":
+        # Only care about engines that will be kept.
+        healthy_retained = [e for e in healthy_engines if e["id"] not in exclude_set]
+        if healthy_retained:
+            return FaultToleranceResult(
+                request_id=request_id,
+                success=False,
+                reason=(
+                    "Some retained engines are still healthy — may have hung "
+                    f"during pause: {healthy_retained}"
+                ),
+            )
+        return None
+
+    # Unknown / future instruction — let it through.
+    return None
+
+
 def make_engine_down_report_socket(vllm_config):
     zmq_ctx = zmq.Context()
     zmq_addr = get_engine_client_zmq_addr(


### PR DESCRIPTION
Replace the blanket healthy-engine check in handle_fault with a per-instruction validation function in fault_tolerance/utils.py:

- pause: always allowed — pause itself transitions healthy engines, so rejecting on healthy would create a deadlock
- retry: rejected if any engine is still healthy (may have hung during pause)
- scale_down: only retained engines are checked; exclude_dp_ranks are being removed anyway so their hung/healthy state is irrelevant
- unknown instructions: passed through without validation

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

