### PR TITLE
Initial support for fault tolerant ep

### DIFF
--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -355,6 +355,17 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         torch.accelerator.synchronize()
         DeepEPLLAll2AllManager._last_mask = None
 
+    def update_mask(self, rank: int, masked: bool = True) -> None:
+        buf = DeepEPLLAll2AllManager._buffer
+        assert buf is not None
+        buf.low_latency_update_mask_buffer(rank, masked)
+        torch.accelerator.synchronize()
+        if DeepEPLLAll2AllManager._last_mask is None:
+            DeepEPLLAll2AllManager._last_mask = torch.zeros(
+                self.world_size, device="cuda", dtype=torch.int32
+            )
+        DeepEPLLAll2AllManager._last_mask[rank] = int(masked)
+
     def query_fault(self) -> tuple[torch.Tensor, torch.Tensor]:
         current = self.query_active_mask()
         if DeepEPLLAll2AllManager._last_mask is None:
@@ -568,6 +579,17 @@ class NixlEPAll2AllManager(All2AllManagerBase):
         state.buffer.clean_mask_buffer()
         torch.accelerator.synchronize()
         NixlEPAll2AllManager._last_mask = None
+
+    def update_mask(self, rank: int, masked: bool = True) -> None:
+        state = NixlEPAll2AllManager._buffer
+        assert state is not None
+        state.buffer.update_mask_buffer(rank, mask=masked)
+        torch.accelerator.synchronize()
+        if NixlEPAll2AllManager._last_mask is None:
+            NixlEPAll2AllManager._last_mask = torch.zeros(
+                state.active_ep_size, device="cuda", dtype=torch.int32
+            )
+        NixlEPAll2AllManager._last_mask[rank] = int(masked)
 
     def query_fault(self) -> tuple[torch.Tensor, torch.Tensor]:
         current = self.query_active_mask()

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -111,6 +111,10 @@ class All2AllManagerBase:
         """Clean RDMA buffers and mask state during FT retry."""
         raise NotImplementedError
 
+    def update_mask(self, rank: int, masked: bool = True) -> None:
+        """Set mask for a specific EP rank. Used during scale-down."""
+        raise NotImplementedError
+
     def query_fault(self) -> tuple[torch.Tensor, torch.Tensor]:
         """Returns (has_fault scalar, current_active_mask)."""
         raise NotImplementedError

--- a/vllm/distributed/elastic_ep/ft_eplb_redistribute.py
+++ b/vllm/distributed/elastic_ep/ft_eplb_redistribute.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""EPLB placement-table redistribution and weight reload after peer death.
+
+All redistribution operations are deterministic with stable iteration
+order, so all surviving ranks running the same function with the same
+args produce bit-identical results — no cross-rank communication during
+recovery.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from itertools import zip_longest
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def compute_dead_ep_ranks(
+    dead_dp_ranks: set[int] | list[int],
+    tp_size: int,
+) -> set[int]:
+    """Expand dead DP ranks to the corresponding dead EP ranks."""
+    dead_ep: set[int] = set()
+    for dp_rank in dead_dp_ranks:
+        for tp_offset in range(tp_size):
+            dead_ep.add(dp_rank * tp_size + tp_offset)
+    return dead_ep
+
+
+def mark_dead_columns_inplace(
+    physical_to_logical_map: torch.Tensor,
+    dead_ep_ranks: set[int],
+    num_local_experts: int,
+) -> None:
+    """Mark dead EP ranks' columns as -1 in place.
+
+    physical_to_logical_map is [num_moe_layers, num_physical]; each EP
+    rank owns num_local_experts consecutive columns starting at
+    rank * num_local_experts. Shape stays constant (no topology change).
+    """
+    num_physical = physical_to_logical_map.shape[1]
+    ep_world_size = num_physical // num_local_experts
+    for ep_rank in dead_ep_ranks:
+        if ep_rank < 0 or ep_rank >= ep_world_size:
+            raise ValueError(
+                f"ep_rank={ep_rank} out of bounds for ep_world_size={ep_world_size}"
+            )
+        start = ep_rank * num_local_experts
+        end = start + num_local_experts
+        physical_to_logical_map[:, start:end] = -1
+
+
+def redistribute_expert_placement(
+    physical_to_logical_map: torch.Tensor,
+    num_logical: int,
+    num_local_experts: int,
+) -> set[tuple[int, int]]:
+    """Steals slots from over-replicated experts (donors with >1 replica)
+    to recover missing logical experts, interleaving across EP ranks
+    for balanced weight loading. Modifies physical_to_logical_map in place.
+
+    Returns:
+        Set of (layer_idx, logical_id) pairs needing weight reload.
+
+    Raises:
+        RuntimeError: If not enough slots to cover missing experts.
+    """
+    if physical_to_logical_map.ndim != 2:
+        raise ValueError(
+            f"physical_to_logical_map must be 2D; got shape "
+            f"{tuple(physical_to_logical_map.shape)}"
+        )
+
+    num_layers, num_physical = physical_to_logical_map.shape
+    all_logical = set(range(num_logical))
+    reassignments: set[tuple[int, int]] = set()
+
+    for layer_idx in range(num_layers):
+        layer = physical_to_logical_map[layer_idx]
+
+        replica_count: dict[int, int] = {}
+        for phys_idx in range(num_physical):
+            lid = int(layer[phys_idx].item())
+            if lid >= 0:
+                replica_count[lid] = replica_count.get(lid, 0) + 1
+
+        missing = sorted(all_logical - set(replica_count.keys()))
+        if not missing:
+            continue
+
+        # Group donors by EP rank, most-redundant first within each
+        rank_donors: dict[int, list[tuple[int, int]]] = {}
+        for phys_idx in range(num_physical):
+            lid = int(layer[phys_idx].item())
+            if lid >= 0 and replica_count.get(lid, 0) > 1:
+                ep_rank = phys_idx // num_local_experts
+                rank_donors.setdefault(ep_rank, []).append(
+                    (replica_count[lid], phys_idx)
+                )
+        for bucket in rank_donors.values():
+            bucket.sort(reverse=True)
+
+        # Interleave across ranks (round-robin) so reassignments
+        # spread evenly — each rank loads ~equal new weights.
+        interleaved: list[tuple[int, int]] = []
+        for items in zip_longest(*[rank_donors[r] for r in sorted(rank_donors)]):
+            for item in items:
+                if item is not None:
+                    interleaved.append(item)
+        slot_iter = iter(interleaved)
+
+        for logical_id in missing:
+            while True:
+                candidate = next(slot_iter, None)
+                if candidate is None:
+                    raise RuntimeError(
+                        f"Layer {layer_idx}: no redundant slot for "
+                        f"missing expert {logical_id}. "
+                        f"EPLB redundancy insufficient."
+                    )
+                _, global_slot = candidate
+                old_lid = int(layer[global_slot].item())
+                if replica_count.get(old_lid, 0) > 1:
+                    layer[global_slot] = logical_id
+                    replica_count[old_lid] -= 1
+                    reassignments.add((layer_idx, logical_id))
+                    break
+
+    return reassignments
+
+
+def rebuild_logical_expert_maps(
+    physical_to_logical_map: torch.Tensor,
+    logical_to_physical_map: torch.Tensor,
+    logical_replica_count: torch.Tensor,
+) -> None:
+    """Rebuild logical_to_physical_map and logical_replica_count from
+    physical_to_logical_map, in place.
+
+    Layouts:
+    - physical_to_logical_map: [num_layers, num_physical]
+    - logical_to_physical_map: [num_layers, num_logical, max_replicas]
+    - logical_replica_count: [num_layers, num_logical]
+    """
+    num_layers, num_physical = physical_to_logical_map.shape
+    logical_replica_count.zero_()
+    logical_to_physical_map.fill_(-1)
+    for layer_idx in range(num_layers):
+        for phys_idx in range(num_physical):
+            lid = int(physical_to_logical_map[layer_idx, phys_idx].item())
+            if lid < 0:
+                continue
+            c = int(logical_replica_count[layer_idx, lid].item())
+            if c < logical_to_physical_map.shape[2]:
+                logical_to_physical_map[layer_idx, lid, c] = phys_idx
+            logical_replica_count[layer_idx, lid] += 1
+
+
+def _parse_layer_expert(name: str) -> tuple[int, int] | None:
+    """Extract (layer_idx, logical_expert_id) from a tensor name.
+
+    Returns None for non-expert tensors. Expects HF convention:
+    model.layers.{L}.mlp.experts.{E}.{shard}.weight
+    """
+    parts = name.split(".")
+    try:
+        layer_pos = parts.index("layers")
+        expert_pos = parts.index("experts")
+    except ValueError:
+        return None
+    try:
+        layer_idx = int(parts[layer_pos + 1])
+        expert_id = int(parts[expert_pos + 1])
+    except (IndexError, ValueError):
+        return None
+    return layer_idx, expert_id
+
+
+def reload_experts_from_disk(
+    model: torch.nn.Module,
+    vllm_config: VllmConfig,
+    reload_set: set[tuple[int, int]],
+) -> int:
+    """Reload specific (layer, logical_expert) weights from disk.
+
+    Args:
+        reload_set: {(layer_idx, logical_expert_id), ...} from
+            redistribute_expert_placement.
+
+    Returns:
+        Number of parameter names loaded.
+    """
+    if not reload_set:
+        return 0
+
+    from vllm.model_executor.model_loader.default_loader import (
+        DefaultModelLoader,
+    )
+
+    loader = DefaultModelLoader(vllm_config.load_config)
+    loader.local_expert_ids = None
+
+    all_weights = loader.get_all_weights(vllm_config.model_config, model)
+
+    def filtered_iter() -> Generator[tuple[str, torch.Tensor], None, None]:
+        for name, tensor in all_weights:
+            parsed = _parse_layer_expert(name)
+            if parsed is not None and parsed in reload_set:
+                yield name, tensor
+
+    logger.info("[FT] Reloading %d (layer, expert) pair(s) from disk.", len(reload_set))
+
+    loaded = model.load_weights(filtered_iter())
+
+    logger.info(
+        "[FT] Expert weight reload complete: loaded=%d tensors.",
+        len(loaded) if loaded else 0,
+    )
+    return len(loaded) if loaded else 0

--- a/vllm/entrypoints/serve/fault_tolerance/api_router.py
+++ b/vllm/entrypoints/serve/fault_tolerance/api_router.py
@@ -17,7 +17,12 @@ logger = init_logger(__name__)
 
 router = APIRouter()
 
-_ALLOWED_INSTRUCTIONS = {"retry"}
+_ALLOWED_INSTRUCTIONS = {"retry", "scale_down"}
+
+_REQUIRED_PARAMS: dict[str, set[str]] = {
+    "retry": {"timeout"},
+    "scale_down": {"removed_dp_ranks"},
+}
 
 
 def _validate_payload(body: dict) -> tuple[str, dict]:
@@ -27,8 +32,12 @@ def _validate_payload(body: dict) -> tuple[str, dict]:
         raise HTTPException(400, "'instruction' and 'params' are required.")
     if instruction not in _ALLOWED_INSTRUCTIONS:
         raise HTTPException(400, f"Invalid instruction: '{instruction}'.")
-    if "timeout" not in params or not isinstance(params["timeout"], (int, float)):
-        raise HTTPException(400, "Missing or invalid 'timeout' parameter.")
+    required = _REQUIRED_PARAMS.get(instruction, set())
+    missing = required - set(params.keys())
+    if missing:
+        raise HTTPException(
+            400, f"Missing params for '{instruction}': {sorted(missing)}"
+        )
     return instruction, params
 
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -945,6 +945,9 @@ class EngineCoreProc(EngineCore):
                 vllm_config.parallel_config.enable_fault_tolerance
             )
             if self.enable_fault_tolerance:
+                assert isinstance(self, DPEngineCoreProc), (
+                    "Fault tolerance is only supported in Multi-DP mode."
+                )
                 self.ft_sentinel = EngineCoreSentinel(
                     engine=self,
                     parallel_config=vllm_config.parallel_config,

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -118,18 +118,17 @@ class EngineCoreSentinel:
         parallel_config.data_parallel_rank = new_dp_rank
         engine.dp_rank = new_dp_rank
         engine.dp_size = new_dp_size
+        self.engine_index = new_dp_rank
 
         # Rank 0 hosts the TCPStore master; rebuild if it was removed.
         if 0 in removed_set and hasattr(engine, "dp_store"):
             dp_store_port = ft_request.params.get("dp_store_port")
-            if dp_store_port is None:
-                raise ValueError(
-                    "dp_store_port required when rank 0 is removed "
-                    "(old dp_store master is dead)"
-                )
             new_master_ip = ft_request.params.get("dp_master_ip")
-            if new_master_ip is not None:
-                parallel_config.data_parallel_master_ip = new_master_ip
+            if dp_store_port is None or new_master_ip is None:
+                raise ValueError(
+                    "dp_store_port and dp_master_ip required when rank 0 is removed "
+                )
+            parallel_config.data_parallel_master_ip = new_master_ip
             self._rebuild_dp_store(
                 parallel_config.data_parallel_master_ip,
                 dp_store_port,

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -17,7 +17,7 @@ from vllm.v1.request import RequestStatus
 from vllm.v1.serial_utils import UtilityResult, run_method
 
 if TYPE_CHECKING:
-    from vllm.v1.engine.core import EngineCoreProc
+    from vllm.v1.engine.core import DPEngineCoreProc, EngineCoreProc
 
 logger = init_logger(__name__)
 
@@ -27,7 +27,7 @@ FT_UTILITY_METHOD = "handle_fault_tolerance"
 class EngineCoreSentinel:
     """Manages fault tolerance state for a single engine core."""
 
-    def __init__(self, engine: "EngineCoreProc", parallel_config):
+    def __init__(self, engine: "DPEngineCoreProc", parallel_config):
         self.engine = engine
         self.engine_index = engine.engine_index
         self.parallel_config = parallel_config
@@ -100,38 +100,147 @@ class EngineCoreSentinel:
         self.resumed.set()
         return {"request_id": ft_request.request_id, "success": True}
 
-    def _reinit_dp_group(self) -> dict:
-        """Reinit DP process group if in DP mode. Returns worker params."""
+    def scale_down(self, ft_request: FaultToleranceRequest) -> dict:
+        engine = self.engine
+        parallel_config = engine.vllm_config.parallel_config
+        removed_dp_ranks = ft_request.params["removed_dp_ranks"]
+
+        old_dp_size = parallel_config.data_parallel_size
+        old_dp_rank = parallel_config.data_parallel_rank
+        new_dp_size = old_dp_size - len(removed_dp_ranks)
+        removed_set = set(removed_dp_ranks)
+
+        # Densify: map old sparse ranks to new contiguous ranks.
+        surviving = [r for r in range(old_dp_size) if r not in removed_set]
+        new_dp_rank = surviving.index(old_dp_rank)
+
+        parallel_config.data_parallel_size = new_dp_size
+        parallel_config.data_parallel_rank = new_dp_rank
+        engine.dp_rank = new_dp_rank
+        engine.dp_size = new_dp_size
+
+        # Rank 0 hosts the TCPStore master; rebuild if it was removed.
+        if 0 in removed_set and hasattr(engine, "dp_store"):
+            dp_store_port = ft_request.params.get("dp_store_port")
+            if dp_store_port is None:
+                raise ValueError(
+                    "dp_store_port required when rank 0 is removed "
+                    "(old dp_store master is dead)"
+                )
+            new_master_ip = ft_request.params.get("dp_master_ip")
+            if new_master_ip is not None:
+                parallel_config.data_parallel_master_ip = new_master_ip
+            self._rebuild_dp_store(
+                parallel_config.data_parallel_master_ip,
+                dp_store_port,
+                new_dp_rank,
+                new_dp_size,
+            )
+
+        with set_current_vllm_config(engine.vllm_config):
+            reinit_result = self._reinit_dp_group(
+                new_dp_size=new_dp_size,
+                new_dp_rank=new_dp_rank,
+            )
+
+        if hasattr(engine, "step_counter"):
+            engine.step_counter = 0
+
+        ft_request.params.update(
+            {
+                "new_dp_size": new_dp_size,
+                "new_dp_rank": new_dp_rank,
+            }
+        )
+        ft_request.params.update(reinit_result)
+
+        engine.model_executor.collective_rpc("handle_ft_command", args=(ft_request,))
+
+        self.status_type = EngineStatusType.HEALTHY
+        logger.info(
+            "[FT] Engine %d scale_down complete: dp_size %d->%d, "
+            "dp_rank %d->%d, removed %s",
+            self.engine_index,
+            old_dp_size,
+            new_dp_size,
+            old_dp_rank,
+            new_dp_rank,
+            removed_dp_ranks,
+        )
+        self.resumed.set()
+        return {"request_id": ft_request.request_id, "success": True}
+
+    def _rebuild_dp_store(
+        self,
+        host: str,
+        port: int,
+        dp_rank: int,
+        dp_size: int,
+    ) -> None:
+        """Rebuild dp_store when the old master (rank 0) is dead."""
+        from datetime import timedelta
+
+        from torch.distributed import TCPStore
+
+        self.engine.dp_store = TCPStore(
+            host,
+            port,
+            dp_size,
+            is_master=(dp_rank == 0),
+            timeout=timedelta(seconds=self.engine_recovery_timeout_sec),
+        )
+
+    def _reinit_dp_group(
+        self,
+        new_dp_size: int | None = None,
+        new_dp_rank: int | None = None,
+    ) -> dict:
+        """Reinit DP process group. Returns worker params."""
         engine = self.engine
         if not hasattr(engine, "dp_group") or not hasattr(engine, "dp_store"):
             return {}
 
         parallel_config = engine.vllm_config.parallel_config
-        worker_key = f"ft_worker_dp_port_{self._dp_reinit_epoch}"
-        engine_key = f"ft_engine_dp_port_{self._dp_reinit_epoch}"
-        self._dp_reinit_epoch += 1
+        dp_rank = (
+            new_dp_rank
+            if new_dp_rank is not None
+            else (parallel_config.data_parallel_rank)
+        )
+        dp_size = (
+            new_dp_size
+            if new_dp_size is not None
+            else (parallel_config.data_parallel_size)
+        )
+        dp_master_ip = parallel_config.data_parallel_master_ip
 
-        if parallel_config.data_parallel_rank == 0:
-            worker_port = get_open_port()
-            engine_port = get_open_port()
-            engine.dp_store.set(worker_key, str(worker_port).encode())
-            engine.dp_store.set(engine_key, str(engine_port).encode())
-        else:
-            worker_port = int(engine.dp_store.get(worker_key).decode())
-            engine_port = int(engine.dp_store.get(engine_key).decode())
+        worker_port = self._coordinate_port("ft_worker_dp_port")
+        engine_port = self._coordinate_port("ft_engine_dp_port")
+        self._dp_reinit_epoch += 1
 
         stateless_destroy_torch_distributed_process_group(engine.dp_group)
         engine.dp_group, engine.dp_store = (
             stateless_init_torch_distributed_process_group(
-                parallel_config.data_parallel_master_ip,
+                dp_master_ip,
                 engine_port,
-                parallel_config.data_parallel_rank,
-                parallel_config.data_parallel_size,
+                dp_rank,
+                dp_size,
                 backend="gloo",
                 return_store=True,
             )
         )
         return {"new_stateless_dp_group_port": worker_port}
+
+    def _coordinate_port(self, key_prefix: str) -> int:
+        """Rank 0 picks a fresh port, publishes via dp_store;
+        others block-read it."""
+        key = f"{key_prefix}_{self._dp_reinit_epoch}"
+        dp_rank = self.engine.vllm_config.parallel_config.data_parallel_rank
+        if dp_rank == 0:
+            port = get_open_port()
+            self.engine.dp_store.set(key, str(port).encode())
+        else:
+            port = int(self.engine.dp_store.get(key).decode())
+        return port
 
 
 def fault_tolerant_wrapper(busy_loop_func: Callable):

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -126,12 +126,10 @@ class WorkerSentinel:
 
         surviving_slots = (ep_world_size - len(dead_ep_ranks)) * num_local_experts
         if surviving_slots < num_logical:
-            logger.warning(
-                "[FT] Cannot redistribute: %d surviving slots < %d logical experts",
-                surviving_slots,
-                num_logical,
+            raise RuntimeError(
+                f"[FT] Cannot redistribute: {surviving_slots} surviving slots "
+                f"< {num_logical} logical experts. "
             )
-            return
 
         mark_dead_columns_inplace(p2l, dead_ep_ranks, num_local_experts)
         reassignments = redistribute_expert_placement(

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -11,6 +11,13 @@ from vllm.distributed import (
     stateless_destroy_torch_distributed_process_group,
     stateless_init_torch_distributed_process_group,
 )
+from vllm.distributed.elastic_ep.ft_eplb_redistribute import (
+    compute_dead_ep_ranks,
+    mark_dead_columns_inplace,
+    rebuild_logical_expert_maps,
+    redistribute_expert_placement,
+    reload_experts_from_disk,
+)
 from vllm.logger import init_logger
 from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
 from vllm.v1.serial_utils import run_method
@@ -50,22 +57,164 @@ class WorkerSentinel:
         torch.accelerator.synchronize()
         params = ft_request.params
         self._clean_worker_state()
+        self._reset_eplb_async_state()
         if self.dp_size > 1:
-            old_cpu_group = get_dp_group().cpu_group
-            stateless_destroy_torch_distributed_process_group(old_cpu_group)
-            port = params["new_stateless_dp_group_port"]
-            get_dp_group().cpu_group = stateless_init_torch_distributed_process_group(
-                self.data_parallel_master_ip,
-                port,
+            self._reinit_gloo_group(
+                get_dp_group(),
+                params["new_stateless_dp_group_port"],
                 self.dp_rank,
                 self.dp_size,
-                backend="gloo",
             )
             if self.use_ft_backend:
                 comm = get_ep_group().device_communicator
                 assert comm and comm.all2all_manager
                 mgr = comm.all2all_manager
                 mgr.clean_buffers()
+
+    def scale_down(self, ft_request: FaultToleranceRequest):
+        params = ft_request.params
+        port = params["new_stateless_dp_group_port"]
+        removed_dp_ranks = params["removed_dp_ranks"]
+        new_dp_size = params["new_dp_size"]
+        new_dp_rank = params["new_dp_rank"]
+        tp_size = self.worker.parallel_config.tensor_parallel_size
+
+        torch.accelerator.synchronize()
+        self._clean_worker_state()
+        comm = get_ep_group().device_communicator
+        assert comm and comm.all2all_manager
+        mgr = comm.all2all_manager
+        mgr.clean_buffers()
+
+        dead_ep_ranks = compute_dead_ep_ranks(removed_dp_ranks, tp_size)
+        for ep_rank in sorted(dead_ep_ranks):
+            mgr.update_mask(ep_rank, masked=True)
+
+        self._redistribute_experts(dead_ep_ranks)
+
+        self._reinit_gloo_group(get_dp_group(), port, new_dp_rank, new_dp_size)
+        self.worker.parallel_config.data_parallel_size = new_dp_size
+        self.worker.parallel_config.data_parallel_rank = new_dp_rank
+        self.dp_rank = new_dp_rank
+        self.dp_size = new_dp_size
+
+        self.worker.model_runner.eep_eplb_suppressed = True
+        self._reset_eplb_async_state()
+
+        logger.info(
+            "[FT] Worker scale_down complete: dp_size=%d, dp_rank=%d, "
+            "dead_ep_ranks=%s, eplb_suppressed=True",
+            new_dp_size,
+            new_dp_rank,
+            sorted(dead_ep_ranks),
+        )
+
+    def _redistribute_experts(self, dead_ep_ranks: set[int]) -> None:
+        """One-shot expert redistribution after scale-down."""
+        model_runner = self.worker.model_runner
+        assert model_runner.eplb_state is not None
+        eplb_model_state = model_runner.eplb_state.model_states[
+            model_runner.model_config.compute_hash()
+        ]
+
+        p2l = eplb_model_state.physical_to_logical_map
+        l2p = eplb_model_state.logical_to_physical_map
+        lrc = eplb_model_state.logical_replica_count
+        num_logical = lrc.shape[1]
+        ep_world_size = get_ep_group().world_size
+        num_local_experts = p2l.shape[1] // ep_world_size
+
+        surviving_slots = (ep_world_size - len(dead_ep_ranks)) * num_local_experts
+        if surviving_slots < num_logical:
+            logger.warning(
+                "[FT] Cannot redistribute: %d surviving slots < %d logical experts",
+                surviving_slots,
+                num_logical,
+            )
+            return
+
+        mark_dead_columns_inplace(p2l, dead_ep_ranks, num_local_experts)
+        reassignments = redistribute_expert_placement(
+            p2l, num_logical, num_local_experts
+        )
+        rebuild_logical_expert_maps(p2l, l2p, lrc)
+        self._rebuild_expert_maps(p2l)
+
+        if reassignments:
+            reload_experts_from_disk(
+                model_runner.model,
+                self.worker.vllm_config,
+                reassignments,
+            )
+
+        logger.info(
+            "[FT] Expert redistribution: num_logical=%d, "
+            "ep_world_size=%d, reassignments=%d",
+            num_logical,
+            ep_world_size,
+            len(reassignments),
+        )
+
+    def _rebuild_expert_maps(self, p2l: torch.Tensor) -> None:
+        """Rebuild each FusedMoE layer's _expert_map from p2l table."""
+        model = self.worker.model_runner.model
+        moe_layers = getattr(model, "moe_layers", None)
+        if moe_layers is None:
+            return
+
+        ep_rank = get_ep_group().rank_in_group
+        for layer_idx, layer in enumerate(moe_layers):
+            expert_map = getattr(layer, "_expert_map", None)
+            if expert_map is None:
+                routed = getattr(layer, "routed_experts", None)
+                if routed is not None:
+                    expert_map = getattr(routed, "_expert_map", None)
+            if expert_map is None:
+                continue
+            num_local = p2l.shape[1] // layer.moe_config.moe_parallel_config.ep_size
+            local_start = ep_rank * num_local
+            p2l_row = p2l[layer_idx].cpu()
+
+            new_map = torch.full_like(expert_map, -1)
+            for local_idx in range(num_local):
+                lid = int(p2l_row[local_start + local_idx].item())
+                if 0 <= lid < new_map.shape[0]:
+                    new_map[lid] = local_idx
+            expert_map.copy_(new_map)
+
+    def _reset_eplb_async_state(self) -> None:
+        """Clear stale EPLB async state after fault or scale-down."""
+        eplb_state = getattr(self.worker.model_runner, "eplb_state", None)
+        if eplb_state is None:
+            return
+
+        for ms in eplb_state.model_states.values():
+            ms.rebalanced = False
+            ms.pending_result = None
+            ms.expert_load_pass.zero_()
+            ms.expert_load_window.zero_()
+
+        eplb_state.expert_rearrangement_step = 0
+        eplb_state.expert_load_window_step = 0
+
+    def _reinit_gloo_group(
+        self,
+        group_coordinator,
+        port: int,
+        rank: int,
+        size: int,
+    ) -> None:
+        """Destroy old cpu_group and create a new gloo group."""
+        old = group_coordinator.cpu_group
+        if old is not None:
+            stateless_destroy_torch_distributed_process_group(old)
+        group_coordinator.cpu_group = stateless_init_torch_distributed_process_group(
+            self.data_parallel_master_ip,
+            port,
+            rank,
+            size,
+            backend="gloo",
+        )
 
     def _clean_worker_state(self):
         self.worker.model_runner.execute_model_state = None


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

# Scale-Down Test Report — DP4 DeepEP Low-Latency

## Test Plan

**Objective**: Validate elastic scale-down in a DP+EP deployment with fault tolerance enabled — specifically that surviving ranks can detect a killed rank, accept a `scale_down` command from the orchestrator, redistribute expert weights, and resume normal inference.

### Configuration

- Model: Qwen3-30B-A3B (MoE, 128+64 experts)
- `--data-parallel-size 4`, `--enable-expert-parallel`, `--all2all-backend deepep_low_latency`
- `--enable-fault-tolerance`, `--cpu-distributed-timeout-seconds 10`
- `--enable-eplb` with 64 redundant experts
- `--gpu-memory-utilization 0.5`, `--max-model-len 1024`
- 4 independent API server processes (external LB mode)

### Steps

1. **Launch cluster** — Start 4 DP ranks and wait for all engines to be ready and serving.
2. **Baseline inference** — Send chat completion requests to all 4 ranks continuously; verify all return HTTP 200 with normal throughput.
3. **Query FT status** — `GET /fault_tolerance/status` on all ranks; verify all report `healthy`.
4. **Inject fault** — Kill rank 2's worker process and EngineCore process (simulating a full rank crash) while inference requests are in flight.
5. **Observe fault detection** — Verify that:
   - Surviving ranks (R0, R1, R3) detect the dead peer via Gloo CPU allreduce failure.
   - All surviving engines transition to `UNHEALTHY` status.
   - The killed rank's API server exits with `EngineDeadError`.
6. **Query FT status** — `GET /fault_tolerance/status` on surviving ranks; verify they report `unhealthy`.
7. **Send scale_down** — `POST /fault_tolerance/apply` with `{"instruction": "scale_down", ...}` targeting the dead rank (rank 2), to surviving engines (R0, R1, R3).
8. **Verify scale_down completion** — Check that:
   - Expert weights are redistributed across the 3 surviving ranks (reload from disk).
   - DP process group is reinitialized with new world size (3) and updated rank assignments.
   - All surviving engines transition back to `HEALTHY` and resume serving.
9. **Post-recovery inference** — Send chat completion requests to the 3 surviving ranks; verify HTTP 200 and correct model output.

## Test Result: PASSED

| Phase | Observation | Timestamp |
|---|---|---|
| Cluster ready | All 4 ranks initialized, CUDA graphs captured, servers started | 14:28:40 |
| Baseline inference | All ranks serving normally, all HTTP 200 | 14:28:40 – 14:30:30 |
| FT status (pre-fault) | All 4 engines reported `healthy` | 14:30:28 |
| Fault injected | R2 worker + EngineCore killed during active inference | 14:30:38 |
| Fault detected (R1, R3) | Gloo allreduce `Connection reset by peer` — immediate detection, status → UNHEALTHY | 14:30:38 |
| Fault detected (R0) | Gloo allreduce timeout (10s as configured) — status → UNHEALTHY | 14:30:48 |
| R2 exits | API server received `EngineDeadError`, returned HTTP 500, shut down cleanly | 14:31:00 |
| FT status (post-fault) | Surviving engines (R0, R1, R3) reported `unhealthy` | 14:31:01 |
| Scale-down sent | `POST /fault_tolerance/apply` to R0, R1, R3 | 14:31:28 |
| Expert redistribution | 1176 (layer, expert) pairs reloaded from disk across 3 ranks (~2s) | 14:31:28 – 14:31:30 |
| Scale-down complete | R0: dp 4→3 rank 0→0; R1: dp 4→3 rank 1→1; R3: dp 4→3 rank 3→2 | 14:31:30 |
| Scale-down HTTP response | All 3 surviving ranks returned HTTP 200 for `/fault_tolerance/apply` | 14:31:30 |
| Post-recovery inference | All 3 surviving ranks serving requests with HTTP 200, throughput recovered | 14:31:30 – 14:32:10 |
| Model output correctness | Verified manually — model output is coherent and correct | — |

## Key Observations

- **Fault detection latency**: ~0s for ranks with direct TCP connection to the dead peer (Gloo `Connection reset by peer`); ~10s for ranks that hit the configured `--cpu-distributed-timeout-seconds`.
- **Scale-down duration**: Expert weight reload from disk completed in ~2s (1176 (layer, expert) pairs across 3 ranks).
- **Rank renumbering**: R3 (originally dp_rank=3) was correctly reassigned to dp_rank=2 after rank 2 was removed.
- **EPLB**: Suppressed during scale-down as expected (`eplb_suppressed=True`).
- **No hangs, no silent failures** — all state transitions logged clearly by the sentinel framework.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

